### PR TITLE
fix: 도메인별 errorcode 점검 및 4자리 확장

### DIFF
--- a/src/main/java/com/afternote/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/afternote/domain/admin/controller/AdminController.java
@@ -36,8 +36,8 @@ public class AdminController {
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "대기 중인 인증 요청 목록 조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청 (code: 999)"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한 필요 (code: 605)")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청 (code: 1000)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한 필요 (code: 2005)")
     })
     @GetMapping("/verifications")
     public ApiResponse<List<AdminVerificationResponse>> getPendingVerifications(
@@ -58,9 +58,9 @@ public class AdminController {
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증 요청 상세 조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청 (code: 999)"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한 필요 (code: 605)"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "인증 요청을 찾을 수 없음 (code: 602)")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청 (code: 1000)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한 필요 (code: 2005)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "인증 요청을 찾을 수 없음 (code: 2002)")
     })
     @GetMapping("/verifications/{id}")
     public ApiResponse<AdminVerificationResponse> getVerificationDetail(
@@ -85,10 +85,10 @@ public class AdminController {
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증 요청 승인 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 처리된 인증 요청 (code: 604)"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청 (code: 999)"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한 필요 (code: 605)"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "인증 요청을 찾을 수 없음 (code: 602)")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 처리된 인증 요청 (code: 2004)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청 (code: 1000)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한 필요 (code: 2005)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "인증 요청을 찾을 수 없음 (code: 2002)")
     })
     @PostMapping("/verifications/{id}/approve")
     public ApiResponse<AdminVerificationResponse> approveVerification(
@@ -115,10 +115,10 @@ public class AdminController {
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증 요청 거절 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 처리된 인증 요청 (code: 604)"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청 (code: 999)"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한 필요 (code: 605)"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "인증 요청을 찾을 수 없음 (code: 602)")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 처리된 인증 요청 (code: 2004)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청 (code: 1000)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한 필요 (code: 2005)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "인증 요청을 찾을 수 없음 (code: 2002)")
     })
     @PostMapping("/verifications/{id}/reject")
     public ApiResponse<AdminVerificationResponse> rejectVerification(

--- a/src/main/java/com/afternote/domain/dailyquestion/dto/DailyQuestionTodayResponse.java
+++ b/src/main/java/com/afternote/domain/dailyquestion/dto/DailyQuestionTodayResponse.java
@@ -10,6 +10,9 @@ public class DailyQuestionTodayResponse {
     @Schema(description = "유저 데일리 질문(답변) ID", example = "12")
     private Long questionId;
 
+    @Schema(description = "몇 번째 질문인지 나타내는 day 값", example = "21")
+    private Long day;
+
     @Schema(description = "질문 내용", example = "오늘 가장 감사했던 일은 무엇인가요?")
     private String content;
 

--- a/src/main/java/com/afternote/domain/dailyquestion/service/DailyQuestionService.java
+++ b/src/main/java/com/afternote/domain/dailyquestion/service/DailyQuestionService.java
@@ -68,6 +68,7 @@ public class DailyQuestionService {
 
         return DailyQuestionTodayResponse.builder()
                 .questionId(userDailyQuestion.getId())
+                .day(userDailyQuestion.getDailyQuestion().getId())
                 .content(userDailyQuestion.getDailyQuestion().getContent())
                 .isAnswered(userDailyQuestion.isAnswered())
                 .build();
@@ -75,11 +76,20 @@ public class DailyQuestionService {
 
     @Transactional
     public DailyQuestionAnswerResponse createAnswer(Long userId, DailyQuestionAnswerRequest request) {
+        LocalDate today = LocalDate.now();
         UserDailyQuestion userDailyQuestion = userDailyQuestionRepository.findById(request.getQuestionId())
                 .orElseThrow(() -> new CustomException(ErrorCode.DAILY_QUESTION_NOT_FOUND));
 
         if (!userDailyQuestion.getUser().getId().equals(userId)) {
             throw new CustomException(ErrorCode.NOT_ENOUGH_PERMISSION);
+        }
+
+        if (!today.equals(userDailyQuestion.getQuestionDate())) {
+            throw new CustomException(ErrorCode.DAILY_QUESTION_DATE_MISMATCH);
+        }
+
+        if (userDailyQuestion.isAnswered()) {
+            throw new CustomException(ErrorCode.DAILY_QUESTION_ALREADY_ANSWERED);
         }
 
         userDailyQuestion.updateAnswer(

--- a/src/main/java/com/afternote/domain/deepthought/dto/DeepThoughtResponse.java
+++ b/src/main/java/com/afternote/domain/deepthought/dto/DeepThoughtResponse.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 @Getter
 @Builder
@@ -52,7 +53,13 @@ public class DeepThoughtResponse {
                 .isDraft(deepThought.getIsDraft())
                 .imageUrl(deepThought.getImageUrl())
                 .category(deepThought.getCategory())
-                .tags(deepThought.getTags().stream().map(tag -> tag.getTitle()).toList())
+                .tags(deepThought.getTags().stream()
+                        .map(tag -> tag.getTitle())
+                        .filter(Objects::nonNull)
+                        .map(String::trim)
+                        .filter(tag -> !tag.isBlank())
+                        .map(tag -> tag.startsWith("#") ? tag : "#" + tag)
+                        .toList())
                 .createdAt(formatDate(deepThought.getCreatedAt()))
                 .updatedAt(formatDate(deepThought.getUpdatedAt()))
                 .build();

--- a/src/main/java/com/afternote/domain/deepthought/service/DeepThoughtCategoryService.java
+++ b/src/main/java/com/afternote/domain/deepthought/service/DeepThoughtCategoryService.java
@@ -36,7 +36,7 @@ public class DeepThoughtCategoryService {
     public DeepThoughtCategoryResponse addCategory(Long userId, DeepThoughtCategoryCreateRequest request) {
         String normalizedTitle = request.getTitle().trim();
         if (deepThoughtCategoryRepository.existsByUserIdAndTitle(userId, normalizedTitle)) {
-            throw new CustomException(ErrorCode.CATEGORY_REQUIRED);
+            throw new CustomException(ErrorCode.DEEP_THOUGHT_CATEGORY_DUPLICATE);
         }
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -50,7 +50,13 @@ public class DeepThoughtCategoryService {
         DeepThoughtCategory category = deepThoughtCategoryRepository.findByIdAndUserId(categoryId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_REQUIRED));
 
-        category.updateTitle(request.getTitle().trim());
+        String normalizedTitle = request.getTitle().trim();
+        if (!category.getTitle().equals(normalizedTitle)
+                && deepThoughtCategoryRepository.existsByUserIdAndTitle(userId, normalizedTitle)) {
+            throw new CustomException(ErrorCode.DEEP_THOUGHT_CATEGORY_DUPLICATE);
+        }
+
+        category.updateTitle(normalizedTitle);
         return DeepThoughtCategoryResponse.from(category);
     }
 

--- a/src/main/java/com/afternote/domain/deepthought/service/DeepThoughtService.java
+++ b/src/main/java/com/afternote/domain/deepthought/service/DeepThoughtService.java
@@ -4,6 +4,7 @@ import com.afternote.domain.deepthought.dto.DeepThoughtCreateRequest;
 import com.afternote.domain.deepthought.dto.DeepThoughtListResponse;
 import com.afternote.domain.deepthought.dto.DeepThoughtResponse;
 import com.afternote.domain.deepthought.model.DeepThought;
+import com.afternote.domain.deepthought.repository.DeepThoughtCategoryRepository;
 import com.afternote.domain.deepthought.repository.DeepThoughtRepository;
 import com.afternote.domain.user.model.User;
 import com.afternote.domain.user.repository.UserRepository;
@@ -22,6 +23,7 @@ import java.util.concurrent.ThreadLocalRandom;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class DeepThoughtService {
+    private final DeepThoughtCategoryRepository deepThoughtCategoryRepository;
     private final DeepThoughtRepository deepThoughtRepository;
     private final UserRepository userRepository;
 
@@ -29,6 +31,7 @@ public class DeepThoughtService {
     public DeepThoughtResponse createDeepThought(Long userId, DeepThoughtCreateRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        validateCategoryExists(userId, request.getCategory());
 
         DeepThought deepThought = DeepThought.create(
                 user,
@@ -43,6 +46,17 @@ public class DeepThoughtService {
         DeepThought saved = deepThoughtRepository.save(deepThought);
 
         return DeepThoughtResponse.from(saved);
+    }
+
+    private void validateCategoryExists(Long userId, String categoryTitle) {
+        String normalizedCategory = categoryTitle == null ? null : categoryTitle.trim();
+        if (normalizedCategory == null || normalizedCategory.isBlank()) {
+            throw new CustomException(ErrorCode.DEEP_THOUGHT_CATEGORY_REQUIRED);
+        }
+
+        if (!deepThoughtCategoryRepository.existsByUserIdAndTitle(userId, normalizedCategory)) {
+            throw new CustomException(ErrorCode.DEEP_THOUGHT_CATEGORY_NOT_FOUND);
+        }
     }
 
     public DeepThoughtListResponse getDeepThoughts(Long userId, LocalDate date, String tag, String category) {
@@ -64,12 +78,12 @@ public class DeepThoughtService {
     public DeepThoughtResponse getRandomDeepThought(Long userId) {
         long count = deepThoughtRepository.countByUserId(userId);
         if (count <= 0) {
-            throw new CustomException(ErrorCode.MIND_RECORD_NOT_FOUND);
+            throw new CustomException(ErrorCode.DEEP_THOUGHT_NOT_FOUND);
         }
 
         int randomOffset = ThreadLocalRandom.current().nextInt((int) count);
         DeepThought deepThought = deepThoughtRepository.findByUserIdWithOffset(userId, randomOffset)
-                .orElseThrow(() -> new CustomException(ErrorCode.MIND_RECORD_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.DEEP_THOUGHT_NOT_FOUND));
 
         return DeepThoughtResponse.from(deepThought);
     }
@@ -77,12 +91,12 @@ public class DeepThoughtService {
     @Transactional
     public void deleteDeepThought(Long userId, Long deepThoughtId) {
         DeepThought deepThought = deepThoughtRepository.findByIdAndUserId(deepThoughtId, userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MIND_RECORD_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.DEEP_THOUGHT_NOT_FOUND));
         deepThoughtRepository.delete(deepThought);
     }
 
     public DeepThought getOwnedDeepThought(Long userId, Long deepThoughtId) {
         return deepThoughtRepository.findByIdAndUserId(deepThoughtId, userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MIND_RECORD_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.DEEP_THOUGHT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/afternote/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/afternote/domain/diary/controller/DiaryController.java
@@ -9,6 +9,7 @@ import com.afternote.global.common.ApiResponse;
 import com.afternote.global.resolver.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,11 @@ public class DiaryController {
     private final DiaryService diaryService;
 
     @Operation(summary = "Diary 작성", description = "새로운 다이어리를 작성합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Diary 작성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 올바르지 않음 (code: 1400)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청 (code: 1000)")
+    })
     @PostMapping
     public ApiResponse<DiaryResponse> createDiary(
             @Parameter(hidden = true) @UserId Long userId,
@@ -35,6 +41,11 @@ public class DiaryController {
     }
 
     @Operation(summary = "Diary 조회", description = "날짜 기준으로 다이어리를 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Diary 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 올바르지 않음 (code: 1400)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청 (code: 1000)")
+    })
     @GetMapping
     public ApiResponse<DiaryListResponse> getDiaries(
             @Parameter(hidden = true) @UserId Long userId,
@@ -44,6 +55,12 @@ public class DiaryController {
     }
 
     @Operation(summary = "Diary 수정", description = "다이어리를 수정합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Diary 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 올바르지 않음 (code: 1400)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청 (code: 1000)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "다이어리를 찾을 수 없음 (code: 2100)")
+    })
     @PatchMapping("/{diaryId}")
     public ApiResponse<DiaryResponse> updateDiary(
             @Parameter(hidden = true) @UserId Long userId,
@@ -54,6 +71,11 @@ public class DiaryController {
     }
 
     @Operation(summary = "Diary 삭제", description = "다이어리를 삭제합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Diary 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청 (code: 1000)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "다이어리를 찾을 수 없음 (code: 2100)")
+    })
     @DeleteMapping("/{diaryId}")
     public ApiResponse<Void> deleteDiary(
             @Parameter(hidden = true) @UserId Long userId,

--- a/src/main/java/com/afternote/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/afternote/domain/diary/service/DiaryService.java
@@ -61,7 +61,7 @@ public class DiaryService {
     @Transactional
     public DiaryResponse updateDiary(Long userId, Long diaryId, DiaryUpdateRequest request) {
         Diary diary = diaryRepository.findByIdAndUserId(diaryId, userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MIND_RECORD_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
 
         diary.update(
                 request.getTitle(),
@@ -77,7 +77,7 @@ public class DiaryService {
     @Transactional
     public void deleteDiary(Long userId, Long diaryId) {
         Diary diary = diaryRepository.findByIdAndUserId(diaryId, userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MIND_RECORD_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
         diaryRepository.delete(diary);
     }
 

--- a/src/main/java/com/afternote/global/exception/ErrorCode.java
+++ b/src/main/java/com/afternote/global/exception/ErrorCode.java
@@ -95,20 +95,8 @@ public enum ErrorCode {
     // ======================================                                                                                                                                                               
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, 1400, "요청 값이 올바르지 않습니다."),                                                                                                                       
 
-    // ======================================                                                                                                                                                               
-    // 6. 마음의 기록(MindRecord) 관련 오류 (code: 1500 ~ 1599)                                                                                                                                                   
-    // ======================================                                                                                                                                                               
-    MIND_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, 1500, "마음의 기록을 찾을 수 없습니다."),                                                                                                                    
-    MIND_RECORD_FORBIDDEN(HttpStatus.FORBIDDEN, 1501, "해당 마음의 기록에 대한 권한이 없습니다."),                                                                                                           
-    DAILY_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, 1502, "데일리 질문을 찾을 수 없습니다."),                                                                                                                 
-    DEEP_THOUGHT_CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, 1503, "깊은 생각 카테고리는 필수입니다."),                                                                                                        
-    MIND_RECORD_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, 1504, "마음의 기록 내용은 필수입니다."),                                                                                                            
-    DAILY_QUESTION_REQUIRED(HttpStatus.BAD_REQUEST, 1505, "데일리 질문 ID는 필수입니다."),
-    MIND_RECORD_TITLE_REQUIRED(HttpStatus.BAD_REQUEST, 1506, "마음의 기록 제목은 필수입니다."),
-    RECEIVER_FORBIDDEN(HttpStatus.FORBIDDEN, 1508, "해당 수신인에 대한 접근 권한이 없습니다."),
-
     // ======================================
-    // 7. 애프터노트 관련 오류 (code: 1600 ~ 1699)                                                                                                                                                            
+    // 6. 애프터노트 관련 오류 (code: 1600 ~ 1699)                                                                                                                                                            
     // ======================================                                                                                                                                                               
     AFTERNOTE_NOT_FOUND(HttpStatus.NOT_FOUND, 1600, "애프터노트를 찾을 수 없습니다."),                                                                                                                       
     AFTERNOTE_ACCESS_DENIED(HttpStatus.FORBIDDEN, 1601, "해당 애프터노트에 대한 권한이 없습니다."),                                                                                                          
@@ -135,7 +123,7 @@ public enum ErrorCode {
     THUMBNAIL_URL_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 1622, "썸네일 URL은 공백일 수 없습니다."),                                                                                                         
 
     // ======================================                                                                                                                                                               
-    // 8. 암호화 관련 오류 (code: 1700 ~ 1799)                                                                                                                                                                    
+    // 7. 암호화 관련 오류 (code: 1700 ~ 1799)                                                                                                                                                                    
     // ======================================                                                                                                                                                               
     ENCRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 1700, "암호화 처리 중 오류가 발생했습니다."),                                                                                                        
     DECRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 1701, "복호화 처리 중 오류가 발생했습니다."),
@@ -144,14 +132,14 @@ public enum ErrorCode {
     SOCIAL_LOGIN_USER(HttpStatus.BAD_REQUEST, 1702, "소셜 로그인으로 가입한 계정입니다. 소셜 로그인을 이용해주세요."),
 
     // ======================================
-    // 9. S3/이미지 관련 오류 (code: 1800 ~ 1899)
+    // 8. S3/이미지 관련 오류 (code: 1800 ~ 1899)
     // ======================================
     PRESIGNED_URL_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 1800, "Presigned URL 생성에 실패했습니다."),
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, 1801, "허용되지 않는 파일 확장자입니다. (jpg, jpeg, png, gif, webp, heic, mp4, mov, mp3, m4a, wav, pdf 허용)"),
     INVALID_DIRECTORY(HttpStatus.BAD_REQUEST, 1802, "허용되지 않는 디렉토리입니다."),
 
     // ======================================
-    // 10. 수신자 인증/외부 API 관련 오류 (code: 1900 ~ 1999)
+    // 9. 수신자 인증/외부 API 관련 오류 (code: 1900 ~ 1999)
     // ======================================
     INVALID_AUTH_CODE(HttpStatus.NOT_FOUND, 1900, "유효하지 않은 인증번호입니다."),
 
@@ -159,7 +147,7 @@ public enum ErrorCode {
     GEMINI_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 1901, "LLM API 가 실패하였습니다. 원인은 토큰 만료, 시간 초과 등이 있습니다."),
 
     // ======================================
-    // 11. 전달 조건/인증 관련 오류 (code: 2000 ~ 2099)
+    // 10. 전달 조건/인증 관련 오류 (code: 2000 ~ 2099)
     // ======================================
     VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, 2002, "인증 요청을 찾을 수 없습니다."),
     VERIFICATION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, 2004, "이미 처리된 인증 요청입니다."),
@@ -167,7 +155,27 @@ public enum ErrorCode {
     CONDITION_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, 2006, "설정된 전달 조건과 요청이 일치하지 않습니다."),
     INVALID_DELIVERY_CONDITION(HttpStatus.BAD_REQUEST, 2007, "전달 조건 요청이 올바르지 않습니다."),
     VERIFICATION_ALREADY_SUBMITTED(HttpStatus.CONFLICT, 2008, "이미 대기 중인 인증 요청이 존재합니다."),
-    DELIVERY_CONDITION_NOT_MET(HttpStatus.FORBIDDEN, 2009, "아직 전달 조건이 충족되지 않았습니다.");
+    DELIVERY_CONDITION_NOT_MET(HttpStatus.FORBIDDEN, 2009, "아직 전달 조건이 충족되지 않았습니다."),
+
+    // ======================================
+    // 11. 다이어리 관련 오류 (code: 2100 ~ 2199)
+    // ======================================
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, 2100, "다이어리를 찾을 수 없습니다."),
+
+    // ======================================
+    // 12. 깊은 생각 관련 오류 (code: 2200 ~ 2299)
+    // ======================================
+    DEEP_THOUGHT_NOT_FOUND(HttpStatus.NOT_FOUND, 2200, "깊은 생각을 찾을 수 없습니다."),
+    DEEP_THOUGHT_CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, 2201, "깊은 생각 카테고리는 필수입니다."),
+    DEEP_THOUGHT_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, 2202, "존재하지 않는 깊은 생각 카테고리입니다."),
+    DEEP_THOUGHT_CATEGORY_DUPLICATE(HttpStatus.CONFLICT, 2203, "이미 존재하는 깊은 생각 카테고리입니다."),
+
+    // ======================================
+    // 13. 데일리 질문 관련 오류 (code: 2300 ~ 2399)
+    // ======================================
+    DAILY_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, 2300, "데일리 질문을 찾을 수 없습니다."),
+    DAILY_QUESTION_ALREADY_ANSWERED(HttpStatus.CONFLICT, 2301, "이미 답변이 완료된 데일리 질문입니다."),
+    DAILY_QUESTION_DATE_MISMATCH(HttpStatus.BAD_REQUEST, 2302, "오늘의 데일리 질문만 답변할 수 있습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/afternote/global/exception/ErrorCode.java
+++ b/src/main/java/com/afternote/global/exception/ErrorCode.java
@@ -9,165 +9,165 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // ======================================
-    // 1. 공통 / 인증 / 인가 (code: 999)
+    // 1. 공통 / 인증 / 인가 (code: 1000 ~ 1099)
     // ======================================
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 999, "인증되지 않은 요청입니다."),
-    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, 999, "인증이 필요합니다. 로그인해주세요."),
-    NOT_ENOUGH_PERMISSION(HttpStatus.FORBIDDEN, 999, "권한이 부족합니다."),
-    ENDPOINT_NOT_FOUND(HttpStatus.NOT_FOUND, 999, "존재하지 않는 엔드포인트입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 1000, "인증되지 않은 요청입니다."),
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, 1001, "인증이 필요합니다. 로그인해주세요."),
+    NOT_ENOUGH_PERMISSION(HttpStatus.FORBIDDEN, 1002, "권한이 부족합니다."),
+    ENDPOINT_NOT_FOUND(HttpStatus.NOT_FOUND, 1003, "존재하지 않는 엔드포인트입니다."),
 
     // ======================================
-    // 2. 토큰 관련 오류 (code: 400 ~ 409)
+    // 2. 토큰 관련 오류 (code: 1100 ~ 1199)
     // ======================================
     // Authorization header 미설정
-    MISSING_AUTH_HEADER(HttpStatus.BAD_REQUEST, 400, "Authorization 헤더 미설정"),
+    MISSING_AUTH_HEADER(HttpStatus.BAD_REQUEST, 1100, "Authorization 헤더 미설정"),
 
     // 쿠키 미설정
-    MISSING_COOKIE(HttpStatus.BAD_REQUEST, 401, "쿠키 값 미설정"),
+    MISSING_COOKIE(HttpStatus.BAD_REQUEST, 1101, "쿠키 값 미설정"),
 
     // 엑세스 토큰 만료
-    ACCESS_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, 402, "엑세스 토큰 만료"),
+    ACCESS_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, 1102, "엑세스 토큰 만료"),
 
     // 유효하지 않은 엑세스 토큰
-    INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, 403, "유효하지 않은 엑세스 토큰"),
+    INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, 1103, "유효하지 않은 엑세스 토큰"),
 
     // 엑세스 토큰 타입 미일치
-    ACCESS_TOKEN_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, 404, "엑세스 토큰 타입 미일치"),
+    ACCESS_TOKEN_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, 1104, "엑세스 토큰 타입 미일치"),
 
     // 리프레시 토큰 미설정 (쿠키)
-    MISSING_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, 405, "리프레시 토큰 미설정"),
+    MISSING_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, 1105, "리프레시 토큰 미설정"),
 
     // 리프레시 토큰 만료
-    REFRESH_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, 406, "리프레시 토큰 만료"),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, 1106, "리프레시 토큰 만료"),
 
     // 유효하지 않은 리프레시 토큰
-    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, 407, "유효하지 않은 리프레시 토큰"),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, 1107, "유효하지 않은 리프레시 토큰"),
 
     // 리프레시 토큰 타입 미일치
-    REFRESH_TOKEN_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, 408, "리프레시 토큰 타입 미일치"),
+    REFRESH_TOKEN_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, 1108, "리프레시 토큰 타입 미일치"),
 
     // 사용이 제한된 리프레시 토큰
-    RESTRICTED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, 409, "사용이 제한된 리프레시 토큰"),
+    RESTRICTED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, 1109, "사용이 제한된 리프레시 토큰"),
 
     // ======================================
-    // 3. 회원가입/사용자 관련 오류 (code: 410 ~ 419)
+    // 3. 회원가입/사용자 관련 오류 (code: 1200 ~ 1299)
     // ======================================
     // 이메일 중복
-    DUPLICATE_EMAIL(HttpStatus.CONFLICT, 410, "이미 가입된 이메일입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, 1200, "이미 가입된 이메일입니다."),
 
     // 사용자를 찾을 수 없음
-    USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, 411, "아이디 또는 비밀번호가 일치하지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, 1201, "아이디 또는 비밀번호가 일치하지 않습니다."),
 
     // 비밀번호 불일치
-    PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, 412, "아이디 또는 비밀번호가 일치하지 않습니다."),
+    PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, 1202, "아이디 또는 비밀번호가 일치하지 않습니다."),
 
     // 비밀번호 형식 오류
-    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, 413, "비밀번호는 8자 이상, 영문/숫자/특수문자를 포함해야 합니다."),
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, 1203, "비밀번호는 8자 이상, 영문/숫자/특수문자를 포함해야 합니다."),
 
     // 닉네임 중복
-    DUPLICATE_NAME(HttpStatus.CONFLICT, 414, "이미 사용 중인 이름입니다."),
+    DUPLICATE_NAME(HttpStatus.CONFLICT, 1204, "이미 사용 중인 이름입니다."),
 
     // 계정 비활성화
-    ACCOUNT_DISABLED(HttpStatus.FORBIDDEN, 415, "비활성화된 계정입니다."),
+    ACCOUNT_DISABLED(HttpStatus.FORBIDDEN, 1205, "비활성화된 계정입니다."),
 
-    NEWPASSWORD_MATCH(HttpStatus.BAD_REQUEST, 416, "새 비밀번호와 같습니다."),
+    NEWPASSWORD_MATCH(HttpStatus.BAD_REQUEST, 1206, "새 비밀번호와 같습니다."),
 
-    INVALID_EMAIL_VERIFICATION(HttpStatus.BAD_REQUEST, 417, "인증번호가 유효하지 않습니다."),
+    INVALID_EMAIL_VERIFICATION(HttpStatus.BAD_REQUEST, 1207, "인증번호가 유효하지 않습니다."),
 
     // 소셜 로그인 실패
-    SOCIAL_LOGIN_FAILED(HttpStatus.BAD_REQUEST, 418, "소셜 로그인에 실패했습니다."),
+    SOCIAL_LOGIN_FAILED(HttpStatus.BAD_REQUEST, 1208, "소셜 로그인에 실패했습니다."),
 
     // 지원하지 않는 소셜 로그인 제공자
-    UNSUPPORTED_SOCIAL_LOGIN(HttpStatus.BAD_REQUEST, 419, "지원하지 않는 소셜 로그인 제공자입니다."),
+    UNSUPPORTED_SOCIAL_LOGIN(HttpStatus.BAD_REQUEST, 1209, "지원하지 않는 소셜 로그인 제공자입니다."),
 
     // ======================================
-    // 4. 타임레터 관련 오류 (code: 420 ~ 429)
+    // 4. 타임레터 관련 오류 (code: 1300 ~ 1399)
     // ======================================
-    TIME_LETTER_NOT_FOUND(HttpStatus.NOT_FOUND, 420, "타임레터를 찾을 수 없습니다."),
-    TIME_LETTER_ACCESS_DENIED(HttpStatus.FORBIDDEN, 421, "해당 타임레터에 대한 권한이 없습니다."),
-    TIME_LETTER_ALREADY_SENT(HttpStatus.BAD_REQUEST, 422, "이미 발송된 타임레터는 수정/삭제할 수 없습니다."),
-    TIME_LETTER_INVALID_STATUS(HttpStatus.BAD_REQUEST, 423, "유효하지 않은 상태 변경입니다."),
-    TIME_LETTER_REQUIRED_FIELDS(HttpStatus.BAD_REQUEST, 424, "정식 등록 시 제목, 내용, 발송일시는 필수입니다."),
-    TIME_LETTER_INVALID_SEND_DATE(HttpStatus.BAD_REQUEST, 425, "발송일시는 현재 시간 이후여야 합니다."),
+    TIME_LETTER_NOT_FOUND(HttpStatus.NOT_FOUND, 1300, "타임레터를 찾을 수 없습니다."),
+    TIME_LETTER_ACCESS_DENIED(HttpStatus.FORBIDDEN, 1301, "해당 타임레터에 대한 권한이 없습니다."),
+    TIME_LETTER_ALREADY_SENT(HttpStatus.BAD_REQUEST, 1302, "이미 발송된 타임레터는 수정/삭제할 수 없습니다."),
+    TIME_LETTER_INVALID_STATUS(HttpStatus.BAD_REQUEST, 1303, "유효하지 않은 상태 변경입니다."),
+    TIME_LETTER_REQUIRED_FIELDS(HttpStatus.BAD_REQUEST, 1304, "정식 등록 시 제목, 내용, 발송일시는 필수입니다."),
+    TIME_LETTER_INVALID_SEND_DATE(HttpStatus.BAD_REQUEST, 1305, "발송일시는 현재 시간 이후여야 합니다."),
 
     // ======================================                                                                                                                                                               
-    // 5. 요청 값 검증 오류 (code: 430 ~)                                                                                                                                                                   
+    // 5. 요청 값 검증 오류 (code: 1400 ~ 1499)                                                                                                                                                                   
     // ======================================                                                                                                                                                               
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, 430, "요청 값이 올바르지 않습니다."),                                                                                                                       
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, 1400, "요청 값이 올바르지 않습니다."),                                                                                                                       
 
     // ======================================                                                                                                                                                               
-    // 6. 마음의 기록(MindRecord) 관련 오류 (code: 440 ~)                                                                                                                                                   
+    // 6. 마음의 기록(MindRecord) 관련 오류 (code: 1500 ~ 1599)                                                                                                                                                   
     // ======================================                                                                                                                                                               
-    MIND_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, 440, "마음의 기록을 찾을 수 없습니다."),                                                                                                                    
-    MIND_RECORD_FORBIDDEN(HttpStatus.FORBIDDEN, 441, "해당 마음의 기록에 대한 권한이 없습니다."),                                                                                                           
-    DAILY_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, 442, "데일리 질문을 찾을 수 없습니다."),                                                                                                                 
-    DEEP_THOUGHT_CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, 443, "깊은 생각 카테고리는 필수입니다."),                                                                                                        
-    MIND_RECORD_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, 444, "마음의 기록 내용은 필수입니다."),                                                                                                            
-    DAILY_QUESTION_REQUIRED(HttpStatus.BAD_REQUEST, 445, "데일리 질문 ID는 필수입니다."),
-    MIND_RECORD_TITLE_REQUIRED(HttpStatus.BAD_REQUEST, 446, "마음의 기록 제목은 필수입니다."),
-    RECEIVER_FORBIDDEN(HttpStatus.FORBIDDEN, 448, "해당 수신인에 대한 접근 권한이 없습니다."),
+    MIND_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, 1500, "마음의 기록을 찾을 수 없습니다."),                                                                                                                    
+    MIND_RECORD_FORBIDDEN(HttpStatus.FORBIDDEN, 1501, "해당 마음의 기록에 대한 권한이 없습니다."),                                                                                                           
+    DAILY_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, 1502, "데일리 질문을 찾을 수 없습니다."),                                                                                                                 
+    DEEP_THOUGHT_CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, 1503, "깊은 생각 카테고리는 필수입니다."),                                                                                                        
+    MIND_RECORD_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, 1504, "마음의 기록 내용은 필수입니다."),                                                                                                            
+    DAILY_QUESTION_REQUIRED(HttpStatus.BAD_REQUEST, 1505, "데일리 질문 ID는 필수입니다."),
+    MIND_RECORD_TITLE_REQUIRED(HttpStatus.BAD_REQUEST, 1506, "마음의 기록 제목은 필수입니다."),
+    RECEIVER_FORBIDDEN(HttpStatus.FORBIDDEN, 1508, "해당 수신인에 대한 접근 권한이 없습니다."),
 
     // ======================================
-    // 7. 애프터노트 관련 오류 (code: 460 ~ 479)                                                                                                                                                            
+    // 7. 애프터노트 관련 오류 (code: 1600 ~ 1699)                                                                                                                                                            
     // ======================================                                                                                                                                                               
-    AFTERNOTE_NOT_FOUND(HttpStatus.NOT_FOUND, 460, "애프터노트를 찾을 수 없습니다."),                                                                                                                       
-    AFTERNOTE_ACCESS_DENIED(HttpStatus.FORBIDDEN, 461, "해당 애프터노트에 대한 권한이 없습니다."),                                                                                                          
-    CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, 462, "카테고리는 필수입니다."),                                                                                                                               
-    SOCIAL_CREDENTIALS_REQUIRED(HttpStatus.BAD_REQUEST, 463, "SOCIAL 카테고리는 계정 정보(credentials)가 필수입니다."),                                                                                     
-    SOCIAL_ACCOUNT_ID_REQUIRED(HttpStatus.BAD_REQUEST, 464, "계정 ID는 필수입니다."),                                                                                                                       
-    SOCIAL_ACCOUNT_PASSWORD_REQUIRED(HttpStatus.BAD_REQUEST, 465, "계정 비밀번호는 필수입니다."),                                                                                                           
-    GALLERY_RECEIVERS_REQUIRED(HttpStatus.BAD_REQUEST, 466, "GALLERY 카테고리는 수신자(receivers)가 필수입니다."),                                                                                          
-    GALLERY_RECEIVER_ID_REQUIRED(HttpStatus.BAD_REQUEST, 467, "수신자 ID는 필수입니다."),                                                                                                                   
-    RECEIVER_NOT_FOUND(HttpStatus.NOT_FOUND, 468, "수신자를 찾을 수 없습니다."),
-    PLAYLIST_REQUIRED(HttpStatus.BAD_REQUEST, 469, "PLAYLIST 카테고리는 플레이리스트(playlist)가 필수입니다."),                                                                                             
-    PLAYLIST_SONGS_REQUIRED(HttpStatus.BAD_REQUEST, 470, "플레이리스트에는 최소 1곡 이상이 필요합니다."),                                                                                                   
-    PLAYLIST_SONG_TITLE_REQUIRED(HttpStatus.BAD_REQUEST, 471, "곡 제목은 필수입니다."),
-    PLAYLIST_SONG_ARTIST_REQUIRED(HttpStatus.BAD_REQUEST, 472, "아티스트는 필수입니다."),
-    ACTIONS_REQUIRED(HttpStatus.BAD_REQUEST, 473, "액션(actions)은 최소 1개 이상 필요합니다."),
-    CATEGORY_CANNOT_BE_CHANGED(HttpStatus.BAD_REQUEST, 474, "카테고리는 변경할 수 없습니다."),
-    RECEIVERS_REQUIRED(HttpStatus.BAD_REQUEST, 475, "수신자(receivers)는 최소 1명 이상 필요합니다."),
-    INVALID_FIELD_FOR_SOCIAL(HttpStatus.BAD_REQUEST, 476, "SOCIAL 카테고리는 credentials만 수정할 수 있습니다."),                                                                                           
-    INVALID_FIELD_FOR_GALLERY(HttpStatus.BAD_REQUEST, 477, "GALLERY 카테고리는 receivers만 수정할 수 있습니다."),                                                                                           
-    INVALID_FIELD_FOR_PLAYLIST(HttpStatus.BAD_REQUEST, 478, "PLAYLIST 카테고리는 playlist만 수정할 수 있습니다."),                                                                                          
-    FIELD_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 479, "필드 값은 공백일 수 없습니다."),                                                                                                                    
-    ATMOSPHERE_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 480, "분위기(atmosphere)는 공백일 수 없습니다."),                                                                                                    
-    VIDEO_URL_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 481, "비디오 URL은 공백일 수 없습니다."),                                                                                                             
-    THUMBNAIL_URL_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 482, "썸네일 URL은 공백일 수 없습니다."),                                                                                                         
+    AFTERNOTE_NOT_FOUND(HttpStatus.NOT_FOUND, 1600, "애프터노트를 찾을 수 없습니다."),                                                                                                                       
+    AFTERNOTE_ACCESS_DENIED(HttpStatus.FORBIDDEN, 1601, "해당 애프터노트에 대한 권한이 없습니다."),                                                                                                          
+    CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, 1602, "카테고리는 필수입니다."),                                                                                                                               
+    SOCIAL_CREDENTIALS_REQUIRED(HttpStatus.BAD_REQUEST, 1603, "SOCIAL 카테고리는 계정 정보(credentials)가 필수입니다."),                                                                                     
+    SOCIAL_ACCOUNT_ID_REQUIRED(HttpStatus.BAD_REQUEST, 1604, "계정 ID는 필수입니다."),                                                                                                                       
+    SOCIAL_ACCOUNT_PASSWORD_REQUIRED(HttpStatus.BAD_REQUEST, 1605, "계정 비밀번호는 필수입니다."),                                                                                                           
+    GALLERY_RECEIVERS_REQUIRED(HttpStatus.BAD_REQUEST, 1606, "GALLERY 카테고리는 수신자(receivers)가 필수입니다."),                                                                                          
+    GALLERY_RECEIVER_ID_REQUIRED(HttpStatus.BAD_REQUEST, 1607, "수신자 ID는 필수입니다."),                                                                                                                   
+    RECEIVER_NOT_FOUND(HttpStatus.NOT_FOUND, 1608, "수신자를 찾을 수 없습니다."),
+    PLAYLIST_REQUIRED(HttpStatus.BAD_REQUEST, 1609, "PLAYLIST 카테고리는 플레이리스트(playlist)가 필수입니다."),                                                                                             
+    PLAYLIST_SONGS_REQUIRED(HttpStatus.BAD_REQUEST, 1610, "플레이리스트에는 최소 1곡 이상이 필요합니다."),                                                                                                   
+    PLAYLIST_SONG_TITLE_REQUIRED(HttpStatus.BAD_REQUEST, 1611, "곡 제목은 필수입니다."),
+    PLAYLIST_SONG_ARTIST_REQUIRED(HttpStatus.BAD_REQUEST, 1612, "아티스트는 필수입니다."),
+    ACTIONS_REQUIRED(HttpStatus.BAD_REQUEST, 1613, "액션(actions)은 최소 1개 이상 필요합니다."),
+    CATEGORY_CANNOT_BE_CHANGED(HttpStatus.BAD_REQUEST, 1614, "카테고리는 변경할 수 없습니다."),
+    RECEIVERS_REQUIRED(HttpStatus.BAD_REQUEST, 1615, "수신자(receivers)는 최소 1명 이상 필요합니다."),
+    INVALID_FIELD_FOR_SOCIAL(HttpStatus.BAD_REQUEST, 1616, "SOCIAL 카테고리는 credentials만 수정할 수 있습니다."),                                                                                           
+    INVALID_FIELD_FOR_GALLERY(HttpStatus.BAD_REQUEST, 1617, "GALLERY 카테고리는 receivers만 수정할 수 있습니다."),                                                                                           
+    INVALID_FIELD_FOR_PLAYLIST(HttpStatus.BAD_REQUEST, 1618, "PLAYLIST 카테고리는 playlist만 수정할 수 있습니다."),                                                                                          
+    FIELD_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 1619, "필드 값은 공백일 수 없습니다."),                                                                                                                    
+    ATMOSPHERE_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 1620, "분위기(atmosphere)는 공백일 수 없습니다."),                                                                                                    
+    VIDEO_URL_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 1621, "비디오 URL은 공백일 수 없습니다."),                                                                                                             
+    THUMBNAIL_URL_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 1622, "썸네일 URL은 공백일 수 없습니다."),                                                                                                         
 
     // ======================================                                                                                                                                                               
-    // 8. 암호화 관련 오류 (code: 490 ~)                                                                                                                                                                    
+    // 8. 암호화 관련 오류 (code: 1700 ~ 1799)                                                                                                                                                                    
     // ======================================                                                                                                                                                               
-    ENCRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 490, "암호화 처리 중 오류가 발생했습니다."),                                                                                                        
-    DECRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 491, "복호화 처리 중 오류가 발생했습니다."),
+    ENCRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 1700, "암호화 처리 중 오류가 발생했습니다."),                                                                                                        
+    DECRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 1701, "복호화 처리 중 오류가 발생했습니다."),
 
     // 소셜 로그인 사용자의 일반 로그인 시도
-    SOCIAL_LOGIN_USER(HttpStatus.BAD_REQUEST, 492, "소셜 로그인으로 가입한 계정입니다. 소셜 로그인을 이용해주세요."),
+    SOCIAL_LOGIN_USER(HttpStatus.BAD_REQUEST, 1702, "소셜 로그인으로 가입한 계정입니다. 소셜 로그인을 이용해주세요."),
 
     // ======================================
-    // 9. S3/이미지 관련 오류 (code: 493 ~)
+    // 9. S3/이미지 관련 오류 (code: 1800 ~ 1899)
     // ======================================
-    PRESIGNED_URL_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 493, "Presigned URL 생성에 실패했습니다."),
-    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, 494, "허용되지 않는 파일 확장자입니다. (jpg, jpeg, png, gif, webp, heic, mp4, mov, mp3, m4a, wav, pdf 허용)"),
-    INVALID_DIRECTORY(HttpStatus.BAD_REQUEST, 495, "허용되지 않는 디렉토리입니다."),
+    PRESIGNED_URL_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 1800, "Presigned URL 생성에 실패했습니다."),
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, 1801, "허용되지 않는 파일 확장자입니다. (jpg, jpeg, png, gif, webp, heic, mp4, mov, mp3, m4a, wav, pdf 허용)"),
+    INVALID_DIRECTORY(HttpStatus.BAD_REQUEST, 1802, "허용되지 않는 디렉토리입니다."),
 
     // ======================================
-    // 10. 수신자 인증 관련 오류 (code: 496 ~)
+    // 10. 수신자 인증/외부 API 관련 오류 (code: 1900 ~ 1999)
     // ======================================
-    INVALID_AUTH_CODE(HttpStatus.NOT_FOUND, 496, "유효하지 않은 인증번호입니다."),
+    INVALID_AUTH_CODE(HttpStatus.NOT_FOUND, 1900, "유효하지 않은 인증번호입니다."),
 
     //gemini api
-    GEMINI_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 497, "LLM API 가 실패하였습니다. 원인은 토큰 만료, 시간 초과 등이 있습니다."),
+    GEMINI_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 1901, "LLM API 가 실패하였습니다. 원인은 토큰 만료, 시간 초과 등이 있습니다."),
 
     // ======================================
-    // 11. 전달 조건/인증 관련 오류 (code: 600 ~)
+    // 11. 전달 조건/인증 관련 오류 (code: 2000 ~ 2099)
     // ======================================
-    VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, 602, "인증 요청을 찾을 수 없습니다."),
-    VERIFICATION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, 604, "이미 처리된 인증 요청입니다."),
-    ADMIN_REQUIRED(HttpStatus.FORBIDDEN, 605, "관리자 권한이 필요합니다."),
-    CONDITION_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, 606, "설정된 전달 조건과 요청이 일치하지 않습니다."),
-    INVALID_DELIVERY_CONDITION(HttpStatus.BAD_REQUEST, 607, "전달 조건 요청이 올바르지 않습니다."),
-    VERIFICATION_ALREADY_SUBMITTED(HttpStatus.CONFLICT, 608, "이미 대기 중인 인증 요청이 존재합니다."),
-    DELIVERY_CONDITION_NOT_MET(HttpStatus.FORBIDDEN, 609, "아직 전달 조건이 충족되지 않았습니다.");
+    VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, 2002, "인증 요청을 찾을 수 없습니다."),
+    VERIFICATION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, 2004, "이미 처리된 인증 요청입니다."),
+    ADMIN_REQUIRED(HttpStatus.FORBIDDEN, 2005, "관리자 권한이 필요합니다."),
+    CONDITION_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, 2006, "설정된 전달 조건과 요청이 일치하지 않습니다."),
+    INVALID_DELIVERY_CONDITION(HttpStatus.BAD_REQUEST, 2007, "전달 조건 요청이 올바르지 않습니다."),
+    VERIFICATION_ALREADY_SUBMITTED(HttpStatus.CONFLICT, 2008, "이미 대기 중인 인증 요청이 존재합니다."),
+    DELIVERY_CONDITION_NOT_MET(HttpStatus.FORBIDDEN, 2009, "아직 전달 조건이 충족되지 않았습니다.");
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📌 관련 이슈
close #

## ✨ 작업 내용

### 도메인별 처리 개선
Diary
조회 실패 시 MIND_RECORD_NOT_FOUND → DIARY_NOT_FOUND로 교체
컨트롤러 Swagger 응답 코드 문구 업데이트

DeepThought
생성 시 카테고리 존재 검증 추가(유저 카테고리 테이블 기준)
없는 카테고리 입력 시 DEEP_THOUGHT_CATEGORY_NOT_FOUND
카테고리 추가/수정 시 중복이면 DEEP_THOUGHT_CATEGORY_DUPLICATE
조회 응답 태그 포맷 # prefix 반환으로 통일

DailyQuestion
today 응답에 day(질문 순번) 필드 추가
createAnswer 가드 추가:
이미 답변 완료(answered=true)면 차단
오늘 날짜 질문이 아니면 차단


## 🛠️ 테스트 계획 및 결과
- [X] docker build 완료 (docker-compose up --build )
- [X] API 테스트(Postman/Swagger) 완료

## 📚 체크리스트
- [X] 브랜치 전략에 맞는 브랜치인가요? (`[이름]/[타입]/[기능]`)
- [X] 커밋 메시지 컨벤션을 준수했나요? (`[타입] 제목`)
- [X] 불필요한 주석이나 print문은 제거했나요?

## 스크린샷 (선택)


## 💬 리뷰어에게 (선택)