### PR TITLE
fix: 사망확인 서류 제출 로직 수정 및 DEATH_CERTIFICATE 상태 제거

### DIFF
--- a/src/main/java/com/afternote/domain/receiver/controller/ReceiverAuthController.java
+++ b/src/main/java/com/afternote/domain/receiver/controller/ReceiverAuthController.java
@@ -109,7 +109,7 @@ public class ReceiverAuthController {
 
     @Operation(
             summary = "사망확인 서류 제출",
-            description = "전달 조건이 DEATH_CERTIFICATE인 경우 수신자가 인증 서류를 제출합니다."
+            description = "수신자가 인증 서류를 제출합니다."
     )
     @PostMapping("/delivery-verification")
     public ApiResponse<DeliveryVerificationResponse> submitDeliveryVerification(

--- a/src/main/java/com/afternote/domain/receiver/service/DeliveryVerificationService.java
+++ b/src/main/java/com/afternote/domain/receiver/service/DeliveryVerificationService.java
@@ -35,10 +35,6 @@ public class DeliveryVerificationService {
         User user = userRepository.findById(receiver.getUserId())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        if (user.getDeliveryConditionType() != DeliveryConditionType.DEATH_CERTIFICATE) {
-            throw new CustomException(ErrorCode.CONDITION_TYPE_MISMATCH);
-        }
-
         if (!s3Service.isManagedObjectKeyInDirectory(deathCertUrl, "documents")
                 || !s3Service.isManagedObjectKeyInDirectory(familyRelationCertUrl, "documents")) {
             throw new CustomException(ErrorCode.INVALID_DELIVERY_CONDITION);
@@ -60,16 +56,6 @@ public class DeliveryVerificationService {
                 .build();
 
         return deliveryVerificationRepository.save(verification);
-    }
-
-    @Transactional
-    public void cancelPendingVerifications(Long userId) {
-        List<DeliveryVerification> pendingVerifications =
-                deliveryVerificationRepository.findByUserIdAndStatus(userId, VerificationStatus.PENDING);
-
-        for (DeliveryVerification verification : pendingVerifications) {
-            verification.reject("조건 변경으로 자동 취소");
-        }
     }
 
     public DeliveryVerification getVerificationStatus(String authCode) {

--- a/src/main/java/com/afternote/domain/user/model/DeliveryConditionType.java
+++ b/src/main/java/com/afternote/domain/user/model/DeliveryConditionType.java
@@ -6,8 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public enum DeliveryConditionType {
     @Schema(description = "조건 없음 - 즉시 열람 가능")
     NONE,
-    @Schema(description = "사망 확인 - 사망진단서 및 가족관계증명서 제출 후 관리자 승인 필요")
-    DEATH_CERTIFICATE,
     @Schema(description = "비활동 감지 - 지정한 기간 동안 로그인하지 않으면 전달")
     INACTIVITY,
     @Schema(description = "특정 날짜 - 지정한 날짜가 지나면 전달")

--- a/src/main/java/com/afternote/domain/user/model/User.java
+++ b/src/main/java/com/afternote/domain/user/model/User.java
@@ -155,11 +155,6 @@ public class User extends BaseEntity {
                 this.specificDate = null;
                 this.conditionFulfilled = true;
             }
-            case DEATH_CERTIFICATE -> {
-                this.inactivityPeriodDays = null;
-                this.specificDate = null;
-                this.conditionFulfilled = false;
-            }
             case INACTIVITY -> {
                 if (inactivityPeriodDays == null || inactivityPeriodDays <= 0) {
                     throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
@@ -186,7 +181,6 @@ public class User extends BaseEntity {
     public boolean isDeliveryConditionMet() {
         return switch (this.deliveryConditionType) {
             case NONE -> true;
-            case DEATH_CERTIFICATE -> this.conditionFulfilled;
             case INACTIVITY -> this.inactivityPeriodDays != null
                     && this.getUpdatedAt() != null
                     && this.getUpdatedAt().isBefore(LocalDateTime.now().minusDays(this.inactivityPeriodDays));

--- a/src/main/java/com/afternote/domain/user/service/UserService.java
+++ b/src/main/java/com/afternote/domain/user/service/UserService.java
@@ -142,11 +142,6 @@ public class UserService {
                 request.getSpecificDate()
         );
 
-        if (previousConditionType == DeliveryConditionType.DEATH_CERTIFICATE
-                && user.getDeliveryConditionType() != DeliveryConditionType.DEATH_CERTIFICATE) {
-            deliveryVerificationService.cancelPendingVerifications(user.getId());
-        }
-
         return DeliveryConditionResponse.from(user);
     }
 

--- a/src/main/java/com/afternote/global/common/BaseEntity.java
+++ b/src/main/java/com/afternote/global/common/BaseEntity.java
@@ -2,6 +2,8 @@ package com.afternote.global.common;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -10,10 +12,21 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 public abstract class BaseEntity {
 
-    @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at", nullable = false, insertable = false, updatable = false)
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/afternote/global/common/BaseEntity.java
+++ b/src/main/java/com/afternote/global/common/BaseEntity.java
@@ -2,8 +2,6 @@ package com.afternote.global.common;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -12,21 +10,10 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 public abstract class BaseEntity {
 
-    @Column(name = "created_at", nullable = false, updatable = false)
+    @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at", nullable = false)
+    @Column(name = "updated_at", nullable = false, insertable = false, updatable = false)
     private LocalDateTime updatedAt;
 
-    @PrePersist
-    protected void onCreate() {
-        LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
close #37 

## ✨ 작업 내용
- [x] created_at과 updated_at db에 안 들어가는 문제 수정
- [x] DEATH_CERTIFICATE 상태 제거 및 DB 수정

## 🛠️ 테스트 계획 및 결과
- [ ] docker build 완료 (docker-compose up --build )
- [x] API 테스트(Postman/Swagger) 완료

## 📚 체크리스트
- [x] 브랜치 전략에 맞는 브랜치인가요? (`[이름]/[타입]/[기능]`)
- [x] 커밋 메시지 컨벤션을 준수했나요? (`[타입] 제목`)
- [x] 불필요한 주석이나 print문은 제거했나요?

## 스크린샷 (선택)


## 💬 리뷰어에게 (선택)
아직 배포 DB는 수정 안 하고 로컬 DB만 수정했어요!