### PR TITLE
fix: 마인드레코드 content HTML·sanitizer 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,9 @@ dependencies {
     // AWS S3
     implementation platform('software.amazon.awssdk:bom:2.25.16')
     implementation 'software.amazon.awssdk:s3'
+
+    // 마인드 레코드 본문 HTML sanitize (XSS 완화)
+    implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20240325.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/afternote/domain/dailyquestion/dto/DailyQuestionAnswerRequest.java
+++ b/src/main/java/com/afternote/domain/dailyquestion/dto/DailyQuestionAnswerRequest.java
@@ -1,5 +1,6 @@
 package com.afternote.domain.dailyquestion.dto;
 
+import com.afternote.global.sanitizer.MindRecordHtmlSchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -14,7 +15,7 @@ public class DailyQuestionAnswerRequest {
     @NotNull(message = "질문 ID는 필수입니다.")
     private Long questionId;
 
-    @Schema(description = "답변 내용", example = "오늘 날씨가 좋아서 산책을 다녀왔습니다.")
+    @Schema(description = MindRecordHtmlSchema.CONTENT, example = MindRecordHtmlSchema.CONTENT_EXAMPLE)
     @NotBlank(message = "답변 내용은 필수입니다.")
     private String content;
 

--- a/src/main/java/com/afternote/domain/dailyquestion/dto/DailyQuestionAnswerResponse.java
+++ b/src/main/java/com/afternote/domain/dailyquestion/dto/DailyQuestionAnswerResponse.java
@@ -1,5 +1,6 @@
 package com.afternote.domain.dailyquestion.dto;
 
+import com.afternote.global.sanitizer.MindRecordHtmlSchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +11,7 @@ public class DailyQuestionAnswerResponse {
     @Schema(description = "유저 데일리 질문(답변) ID", example = "12")
     private Long userDailyQuestionId;
 
-    @Schema(description = "답변 내용", example = "오늘 날씨가 좋아서 산책을 다녀왔습니다.")
+    @Schema(description = MindRecordHtmlSchema.CONTENT, example = MindRecordHtmlSchema.CONTENT_EXAMPLE)
     private String content;
 
     @Schema(description = "이미지 URL", example = "https://s3.../image.jpg", nullable = true)

--- a/src/main/java/com/afternote/domain/dailyquestion/dto/DailyQuestionListResponse.java
+++ b/src/main/java/com/afternote/domain/dailyquestion/dto/DailyQuestionListResponse.java
@@ -1,5 +1,6 @@
 package com.afternote.domain.dailyquestion.dto;
 
+import com.afternote.global.sanitizer.MindRecordHtmlSchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +15,7 @@ public class DailyQuestionListResponse {
     @Schema(description = "질문 제목(내용)", example = "오늘 가장 감사했던 일은 무엇인가요?")
     private String title;
 
-    @Schema(description = "답변 내용", example = "가족들과 함께 저녁을 먹은 것")
+    @Schema(description = MindRecordHtmlSchema.CONTENT, example = MindRecordHtmlSchema.CONTENT_EXAMPLE)
     private String content;
 
     @Schema(description = "생성일시 (yyyy.MM.dd E 포맷)", example = "2023.10.12 목")

--- a/src/main/java/com/afternote/domain/dailyquestion/dto/DailyQuestionUpdateRequest.java
+++ b/src/main/java/com/afternote/domain/dailyquestion/dto/DailyQuestionUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.afternote.domain.dailyquestion.dto;
 
+import com.afternote.global.sanitizer.MindRecordHtmlSchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class DailyQuestionUpdateRequest {
 
-    @Schema(description = "수정할 답변 내용", example = "수정된 답변입니다.")
+    @Schema(description = MindRecordHtmlSchema.CONTENT, example = MindRecordHtmlSchema.CONTENT_EXAMPLE)
     private String content;
 
     @Schema(description = "수정할 이미지 URL", example = "https://s3.../new-image.jpg", nullable = true)

--- a/src/main/java/com/afternote/domain/dailyquestion/service/DailyQuestionService.java
+++ b/src/main/java/com/afternote/domain/dailyquestion/service/DailyQuestionService.java
@@ -10,6 +10,7 @@ import com.afternote.domain.user.model.User;
 import com.afternote.domain.user.repository.UserRepository;
 import com.afternote.global.exception.CustomException;
 import com.afternote.global.exception.ErrorCode;
+import com.afternote.global.sanitizer.MindRecordHtmlSanitizer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,7 @@ public class DailyQuestionService {
     private final DailyQuestionRepository dailyQuestionRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final UserRepository userRepository;
+    private final MindRecordHtmlSanitizer mindRecordHtmlSanitizer;
 
     @Transactional
     public DailyQuestionTodayResponse getTodayQuestion(Long userId) {
@@ -96,7 +98,7 @@ public class DailyQuestionService {
         }
 
         userDailyQuestion.updateAnswer(
-                request.getContent(),
+                mindRecordHtmlSanitizer.sanitize(request.getContent()),
                 request.getImageUrl(),
                 request.getIsDraft() != null ? request.getIsDraft() : false
         );
@@ -123,7 +125,9 @@ public class DailyQuestionService {
 
         if (request.getContent() != null || request.getImageUrl() != null || request.getIsDraft() != null) {
             userDailyQuestion.updateAnswer(
-                    request.getContent() != null ? request.getContent() : userDailyQuestion.getContent(),
+                    request.getContent() != null
+                            ? mindRecordHtmlSanitizer.sanitize(request.getContent())
+                            : userDailyQuestion.getContent(),
                     request.getImageUrl() != null ? request.getImageUrl() : userDailyQuestion.getImageUrl(),
                     request.getIsDraft() != null ? request.getIsDraft() : userDailyQuestion.isDraft()
             );

--- a/src/main/java/com/afternote/domain/deepthought/dto/DeepThoughtCreateRequest.java
+++ b/src/main/java/com/afternote/domain/deepthought/dto/DeepThoughtCreateRequest.java
@@ -1,5 +1,6 @@
 package com.afternote.domain.deepthought.dto;
 
+import com.afternote.global.sanitizer.MindRecordHtmlSchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -17,7 +18,7 @@ public class DeepThoughtCreateRequest {
     @NotBlank(message = "제목은 필수입니다.")
     private String title;
 
-    @Schema(description = "내용", example = "오늘은 스스로를 더 이해하는 하루였다.")
+    @Schema(description = MindRecordHtmlSchema.CONTENT, example = MindRecordHtmlSchema.CONTENT_EXAMPLE)
     @NotBlank(message = "내용은 필수입니다.")
     private String content;
 

--- a/src/main/java/com/afternote/domain/deepthought/dto/DeepThoughtResponse.java
+++ b/src/main/java/com/afternote/domain/deepthought/dto/DeepThoughtResponse.java
@@ -1,6 +1,7 @@
 package com.afternote.domain.deepthought.dto;
 
 import com.afternote.domain.deepthought.model.DeepThought;
+import com.afternote.global.sanitizer.MindRecordHtmlSchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,7 +25,7 @@ public class DeepThoughtResponse {
     @Schema(description = "제목", example = "나의 성장에 대한 생각")
     private String title;
 
-    @Schema(description = "내용", example = "오늘은 스스로를 더 이해하는 하루였다.")
+    @Schema(description = MindRecordHtmlSchema.CONTENT, example = MindRecordHtmlSchema.CONTENT_EXAMPLE)
     private String content;
 
     @Schema(description = "임시저장 여부", example = "false")

--- a/src/main/java/com/afternote/domain/deepthought/model/DeepThought.java
+++ b/src/main/java/com/afternote/domain/deepthought/model/DeepThought.java
@@ -26,7 +26,7 @@ public class DeepThought extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String title;
 
-    @Column(nullable = false, length = 500)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Column(name = "is_draft", nullable = false)

--- a/src/main/java/com/afternote/domain/deepthought/service/DeepThoughtService.java
+++ b/src/main/java/com/afternote/domain/deepthought/service/DeepThoughtService.java
@@ -11,6 +11,7 @@ import com.afternote.domain.user.model.User;
 import com.afternote.domain.user.repository.UserRepository;
 import com.afternote.global.exception.CustomException;
 import com.afternote.global.exception.ErrorCode;
+import com.afternote.global.sanitizer.MindRecordHtmlSanitizer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,7 @@ public class DeepThoughtService {
     private final DeepThoughtRepository deepThoughtRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final UserRepository userRepository;
+    private final MindRecordHtmlSanitizer mindRecordHtmlSanitizer;
 
     @Transactional
     public DeepThoughtResponse createDeepThought(Long userId, DeepThoughtCreateRequest request) {
@@ -39,7 +41,7 @@ public class DeepThoughtService {
         DeepThought deepThought = DeepThought.create(
                 user,
                 request.getTitle(),
-                request.getContent(),
+                mindRecordHtmlSanitizer.sanitize(request.getContent()),
                 request.getIsDraft(),
                 request.getImageUrl(),
                 request.getCategory(),

--- a/src/main/java/com/afternote/domain/diary/dto/DiaryCreateRequest.java
+++ b/src/main/java/com/afternote/domain/diary/dto/DiaryCreateRequest.java
@@ -1,6 +1,7 @@
 package com.afternote.domain.diary.dto;
 
 import com.afternote.domain.diary.model.TodayMood;
+import com.afternote.global.sanitizer.MindRecordHtmlSchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -16,7 +17,7 @@ public class DiaryCreateRequest {
     @NotBlank(message = "제목은 필수입니다.")
     private String title;
 
-    @Schema(description = "내용", example = "오늘은 좋은 하루였다.")
+    @Schema(description = MindRecordHtmlSchema.CONTENT, example = MindRecordHtmlSchema.CONTENT_EXAMPLE)
     @NotBlank(message = "내용은 필수입니다.")
     private String content;
 

--- a/src/main/java/com/afternote/domain/diary/dto/DiaryResponse.java
+++ b/src/main/java/com/afternote/domain/diary/dto/DiaryResponse.java
@@ -2,6 +2,7 @@ package com.afternote.domain.diary.dto;
 
 import com.afternote.domain.diary.model.Diary;
 import com.afternote.domain.diary.model.TodayMood;
+import com.afternote.global.sanitizer.MindRecordHtmlSchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,7 +24,7 @@ public class DiaryResponse {
     @Schema(description = "제목")
     private String title;
 
-    @Schema(description = "내용")
+    @Schema(description = MindRecordHtmlSchema.CONTENT, example = MindRecordHtmlSchema.CONTENT_EXAMPLE)
     private String content;
 
     @Schema(description = "임시저장 여부")

--- a/src/main/java/com/afternote/domain/diary/dto/DiaryUpdateRequest.java
+++ b/src/main/java/com/afternote/domain/diary/dto/DiaryUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.afternote.domain.diary.dto;
 
 import com.afternote.domain.diary.model.TodayMood;
+import com.afternote.global.sanitizer.MindRecordHtmlSchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +14,7 @@ public class DiaryUpdateRequest {
     @Schema(description = "제목", example = "수정된 제목")
     private String title;
 
-    @Schema(description = "내용", example = "수정된 내용")
+    @Schema(description = MindRecordHtmlSchema.CONTENT, example = MindRecordHtmlSchema.CONTENT_EXAMPLE)
     private String content;
 
     @Schema(description = "임시저장 여부", example = "true")

--- a/src/main/java/com/afternote/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/afternote/domain/diary/service/DiaryService.java
@@ -11,6 +11,7 @@ import com.afternote.domain.user.model.User;
 import com.afternote.domain.user.repository.UserRepository;
 import com.afternote.global.exception.CustomException;
 import com.afternote.global.exception.ErrorCode;
+import com.afternote.global.sanitizer.MindRecordHtmlSanitizer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -28,6 +29,7 @@ public class DiaryService {
     private final DiaryRepository diaryRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final UserRepository userRepository;
+    private final MindRecordHtmlSanitizer mindRecordHtmlSanitizer;
 
     @Transactional
     public DiaryResponse createDiary(Long userId, DiaryCreateRequest request) {
@@ -37,7 +39,7 @@ public class DiaryService {
         Diary diary = Diary.create(
                 user,
                 request.getTitle(),
-                request.getContent(),
+                mindRecordHtmlSanitizer.sanitize(request.getContent()),
                 request.getIsDraft(),
                 request.getImageUrl(),
                 request.getTodayMood()
@@ -71,7 +73,7 @@ public class DiaryService {
 
         diary.update(
                 request.getTitle(),
-                request.getContent(),
+                request.getContent() != null ? mindRecordHtmlSanitizer.sanitize(request.getContent()) : null,
                 request.getIsDraft(),
                 request.getImageUrl(),
                 request.getTodayMood()

--- a/src/main/java/com/afternote/domain/mindrecord/weekly/dto/WeeklyMindRecordResponse.java
+++ b/src/main/java/com/afternote/domain/mindrecord/weekly/dto/WeeklyMindRecordResponse.java
@@ -1,6 +1,7 @@
 package com.afternote.domain.mindrecord.weekly.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.afternote.global.sanitizer.MindRecordHtmlSchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -47,7 +48,10 @@ public class WeeklyMindRecordResponse {
     @Builder
     public static class WeeklyDailyQuestionItem {
         private String title;
+
+        @Schema(description = MindRecordHtmlSchema.CONTENT, example = MindRecordHtmlSchema.CONTENT_EXAMPLE)
         private String content;
+
         private String date;
     }
 

--- a/src/main/java/com/afternote/global/sanitizer/MindRecordHtmlSanitizer.java
+++ b/src/main/java/com/afternote/global/sanitizer/MindRecordHtmlSanitizer.java
@@ -1,0 +1,46 @@
+package com.afternote.global.sanitizer;
+
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
+import org.owasp.html.Sanitizers;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Pattern;
+
+/**
+ * 마인드 레코드 본문(UTF-8 HTML 조각). 프론트 계약:
+ * <ul>
+ *   <li>정렬: {@code <div style="text-align:left|center|right">} 또는 {@code <p align="left|center|right|justify">}</li>
+ *   <li>제목 / 머릿말 / 부머릿말 / 본문: {@code h1}, {@code h2}, {@code h3}, {@code p}</li>
+ *   <li>이탤릭: {@code em}, {@code i} / 밑줄: {@code u} / 취소선: {@code s}, {@code del}</li>
+ * </ul>
+ * {@code div}·줄바꿈·굵게·링크·이미지는 편집기에서 쓰일 수 있어 제한적으로 허용한다.
+ */
+@Component
+public class MindRecordHtmlSanitizer {
+
+    /** {@code align} 속성 값 (대소문자 무시). */
+    private static final Pattern ALIGN_ATTR = Pattern.compile("(?i)(left|center|right|justify)");
+
+    private static final PolicyFactory POLICY =
+            Sanitizers.LINKS
+                    .and(Sanitizers.IMAGES)
+                    .and(new HtmlPolicyBuilder()
+                            .allowElements(
+                                    "h1", "h2", "h3", "p", "div",
+                                    "em", "i", "u", "s", "del",
+                                    "br", "strong", "b", "span"
+                            )
+                            .allowAttributes("align")
+                            .matching(ALIGN_ATTR)
+                            .onElements("p", "div", "h1", "h2", "h3")
+                            .allowStyling()
+                            .toFactory());
+
+    public String sanitize(String html) {
+        if (html == null) {
+            return null;
+        }
+        return POLICY.sanitize(html);
+    }
+}

--- a/src/main/java/com/afternote/global/sanitizer/MindRecordHtmlSchema.java
+++ b/src/main/java/com/afternote/global/sanitizer/MindRecordHtmlSchema.java
@@ -1,0 +1,17 @@
+package com.afternote.global.sanitizer;
+
+/**
+ * Swagger 등 API 문서용 — 마인드 레코드 본문은 HTML 조각으로 통일한다.
+ */
+public final class MindRecordHtmlSchema {
+
+    public static final String CONTENT =
+            "본문 HTML 조각(UTF-8). WebView 등에 그대로 렌더링 가능한 수준의 태그·스타일이며, "
+                    + "저장 시 서버에서 XSS 완화를 위해 sanitize 된다.";
+
+    public static final String CONTENT_EXAMPLE =
+            "<p style=\"text-align:center\"><strong>오늘</strong>은 좋은 날이에요.</p>";
+
+    private MindRecordHtmlSchema() {
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
close #34 

## ✨ 작업 내용
- html로 주고 받고 하게 content내용을 없애고 
sanitizer로 <script>같은 악성의 가능성이 있는 태그들을 거름

## 🛠️ 테스트 계획 및 결과
- [x] docker build 완료 (docker-compose up --build )
- [x] API 테스트(Postman/Swagger) 완료

## 📚 체크리스트
- [x] 브랜치 전략에 맞는 브랜치인가요? (`[이름]/[타입]/[기능]`)
- [x] 커밋 메시지 컨벤션을 준수했나요? (`[타입] 제목`)
- [x] 불필요한 주석이나 print문은 제거했나요?

## 스크린샷 (선택)

<img width="897" height="699" alt="스크린샷 2026-05-04 오후 10 48 39" src="https://github.com/user-attachments/assets/29cd4121-0001-44fa-adb7-2c5fec94729b" />
<img width="682" height="107" alt="스크린샷 2026-05-04 오후 10 48 54" src="https://github.com/user-attachments/assets/ce3bbc8c-005e-41d6-9fd2-9f785ce02711" />
## 💬 리뷰어에게 (선택)