### PR TITLE
fix: 깊은생각 카테고리 동기화

### DIFF
--- a/src/main/java/com/afternote/domain/deepthought/dto/DeepThoughtResponse.java
+++ b/src/main/java/com/afternote/domain/deepthought/dto/DeepThoughtResponse.java
@@ -53,7 +53,7 @@ public class DeepThoughtResponse {
                 .content(deepThought.getContent())
                 .isDraft(deepThought.getIsDraft())
                 .imageUrl(deepThought.getImageUrl())
-                .category(deepThought.getCategory())
+                .category(deepThought.getCategoryTitle())
                 .tags(deepThought.getTags().stream()
                         .map(tag -> tag.getTitle())
                         .filter(Objects::nonNull)

--- a/src/main/java/com/afternote/domain/deepthought/model/DeepThought.java
+++ b/src/main/java/com/afternote/domain/deepthought/model/DeepThought.java
@@ -35,8 +35,9 @@ public class DeepThought extends BaseEntity {
     @Column(name = "image_url", length = 100)
     private String imageUrl;
 
-    @Column(name = "category", length = 50)
-    private String category;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private DeepThoughtCategory category;
 
     @OneToMany(mappedBy = "deepThought", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DeepThoughtTag> tags = new ArrayList<>();
@@ -47,7 +48,7 @@ public class DeepThought extends BaseEntity {
             String content,
             Boolean isDraft,
             String imageUrl,
-            String category,
+            DeepThoughtCategory category,
             List<String> tags
     ) {
         DeepThought record = new DeepThought();
@@ -56,7 +57,7 @@ public class DeepThought extends BaseEntity {
         record.content = content;
         record.isDraft = isDraft;
         record.imageUrl = imageUrl;
-        record.category = category != null ? category.trim() : null;
+        record.category = category;
         if (tags != null) {
             tags.stream()
                     .filter(tag -> tag != null && !tag.isBlank())
@@ -69,5 +70,9 @@ public class DeepThought extends BaseEntity {
 
     private void addTag(String title) {
         this.tags.add(DeepThoughtTag.create(this, title));
+    }
+
+    public String getCategoryTitle() {
+        return category != null ? category.getTitle() : null;
     }
 }

--- a/src/main/java/com/afternote/domain/deepthought/repository/DeepThoughtCategoryRepository.java
+++ b/src/main/java/com/afternote/domain/deepthought/repository/DeepThoughtCategoryRepository.java
@@ -12,6 +12,8 @@ public interface DeepThoughtCategoryRepository extends JpaRepository<DeepThought
 
     Optional<DeepThoughtCategory> findByIdAndUserId(Long id, Long userId);
 
+    Optional<DeepThoughtCategory> findByUserIdAndTitle(Long userId, String title);
+
     List<DeepThoughtCategory> findByUserIdOrderByIdAsc(Long userId);
 
     boolean existsByUserIdAndTitle(Long userId, String title);

--- a/src/main/java/com/afternote/domain/deepthought/repository/DeepThoughtRepository.java
+++ b/src/main/java/com/afternote/domain/deepthought/repository/DeepThoughtRepository.java
@@ -2,6 +2,7 @@ package com.afternote.domain.deepthought.repository;
 
 import com.afternote.domain.deepthought.model.DeepThought;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -17,9 +18,10 @@ public interface DeepThoughtRepository extends JpaRepository<DeepThought, Long> 
 
     @Query("SELECT DISTINCT dt FROM DeepThought dt " +
             "LEFT JOIN dt.tags t " +
+            "LEFT JOIN dt.category c " +
             "WHERE dt.user.id = :userId " +
             "AND (:start IS NULL OR (dt.createdAt >= :start AND dt.createdAt < :end)) " +
-            "AND (:category IS NULL OR dt.category = :category) " +
+            "AND (:category IS NULL OR c.title = :category) " +
             "AND (:tag IS NULL OR t.title = :tag OR dt.title LIKE CONCAT('%', :tag, '%') OR dt.content LIKE CONCAT('%', :tag, '%')) " +
             "ORDER BY dt.createdAt DESC")
     List<DeepThought> search(
@@ -31,6 +33,10 @@ public interface DeepThoughtRepository extends JpaRepository<DeepThought, Long> 
     );
 
     long countByUserId(Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE DeepThought dt SET dt.category = null WHERE dt.user.id = :userId AND dt.category.id = :categoryId")
+    int clearCategoryByUserIdAndCategoryId(@Param("userId") Long userId, @Param("categoryId") Long categoryId);
 
     @Query(value = "SELECT * FROM deep_thought dt WHERE dt.user_id = :userId LIMIT 1 OFFSET :offset", nativeQuery = true)
     Optional<DeepThought> findByUserIdWithOffset(@Param("userId") Long userId, @Param("offset") int offset);

--- a/src/main/java/com/afternote/domain/deepthought/service/DeepThoughtCategoryService.java
+++ b/src/main/java/com/afternote/domain/deepthought/service/DeepThoughtCategoryService.java
@@ -6,6 +6,7 @@ import com.afternote.domain.deepthought.dto.DeepThoughtCategoryResponse;
 import com.afternote.domain.deepthought.dto.DeepThoughtCategoryUpdateRequest;
 import com.afternote.domain.deepthought.model.DeepThoughtCategory;
 import com.afternote.domain.deepthought.repository.DeepThoughtCategoryRepository;
+import com.afternote.domain.deepthought.repository.DeepThoughtRepository;
 import com.afternote.domain.user.model.User;
 import com.afternote.domain.user.repository.UserRepository;
 import com.afternote.global.exception.CustomException;
@@ -21,6 +22,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class DeepThoughtCategoryService {
     private final DeepThoughtCategoryRepository deepThoughtCategoryRepository;
+    private final DeepThoughtRepository deepThoughtRepository;
     private final UserRepository userRepository;
 
     public DeepThoughtCategoryListResponse getCategories(Long userId) {
@@ -64,6 +66,7 @@ public class DeepThoughtCategoryService {
     public void deleteCategory(Long userId, Long categoryId) {
         DeepThoughtCategory category = deepThoughtCategoryRepository.findByIdAndUserId(categoryId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_REQUIRED));
+        deepThoughtRepository.clearCategoryByUserIdAndCategoryId(userId, category.getId());
         deepThoughtCategoryRepository.delete(category);
     }
 }

--- a/src/main/java/com/afternote/domain/deepthought/service/DeepThoughtService.java
+++ b/src/main/java/com/afternote/domain/deepthought/service/DeepThoughtService.java
@@ -4,6 +4,7 @@ import com.afternote.domain.deepthought.dto.DeepThoughtCreateRequest;
 import com.afternote.domain.deepthought.dto.DeepThoughtListResponse;
 import com.afternote.domain.deepthought.dto.DeepThoughtResponse;
 import com.afternote.domain.deepthought.model.DeepThought;
+import com.afternote.domain.deepthought.model.DeepThoughtCategory;
 import com.afternote.domain.deepthought.repository.DeepThoughtCategoryRepository;
 import com.afternote.domain.deepthought.repository.DeepThoughtRepository;
 import com.afternote.domain.mindrecord.emotion.event.DeepThoughtEmotionAnalysisRequestedEvent;
@@ -36,7 +37,7 @@ public class DeepThoughtService {
     public DeepThoughtResponse createDeepThought(Long userId, DeepThoughtCreateRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        validateCategoryExists(userId, request.getCategory());
+        DeepThoughtCategory category = getCategory(userId, request.getCategory());
 
         DeepThought deepThought = DeepThought.create(
                 user,
@@ -44,7 +45,7 @@ public class DeepThoughtService {
                 mindRecordHtmlSanitizer.sanitize(request.getContent()),
                 request.getIsDraft(),
                 request.getImageUrl(),
-                request.getCategory(),
+                category,
                 request.getTags()
         );
 
@@ -56,15 +57,14 @@ public class DeepThoughtService {
         return DeepThoughtResponse.from(saved);
     }
 
-    private void validateCategoryExists(Long userId, String categoryTitle) {
+    private DeepThoughtCategory getCategory(Long userId, String categoryTitle) {
         String normalizedCategory = categoryTitle == null ? null : categoryTitle.trim();
         if (normalizedCategory == null || normalizedCategory.isBlank()) {
             throw new CustomException(ErrorCode.DEEP_THOUGHT_CATEGORY_REQUIRED);
         }
 
-        if (!deepThoughtCategoryRepository.existsByUserIdAndTitle(userId, normalizedCategory)) {
-            throw new CustomException(ErrorCode.DEEP_THOUGHT_CATEGORY_NOT_FOUND);
-        }
+        return deepThoughtCategoryRepository.findByUserIdAndTitle(userId, normalizedCategory)
+                .orElseThrow(() -> new CustomException(ErrorCode.DEEP_THOUGHT_CATEGORY_NOT_FOUND));
     }
 
     public DeepThoughtListResponse getDeepThoughts(Long userId, LocalDate date, String tag, String category) {
@@ -75,12 +75,22 @@ public class DeepThoughtService {
             end = date.plusDays(1).atStartOfDay();
         }
 
-        List<DeepThoughtResponse> list = deepThoughtRepository.search(userId, start, end, tag, category)
+        String normalizedCategory = normalizeSearchParam(category);
+        String normalizedTag = normalizeSearchParam(tag);
+
+        List<DeepThoughtResponse> list = deepThoughtRepository.search(userId, start, end, normalizedTag, normalizedCategory)
                 .stream()
                 .map(DeepThoughtResponse::from)
                 .toList();
 
         return DeepThoughtListResponse.from(list);
+    }
+
+    private String normalizeSearchParam(String value) {
+        if (value == null || value.trim().isBlank()) {
+            return null;
+        }
+        return value.trim();
     }
 
     public DeepThoughtResponse getRandomDeepThought(Long userId) {


### PR DESCRIPTION
## 📌 관련 이슈
close #

## ✨ 작업 내용
- 깊은생각 카테고리를 문자열 저장 방식에서 `DeepThoughtCategory` FK 참조 방식으로 변경했습니다.
- 깊은생각 생성/조회/필터링이 카테고리 엔티티 기준으로 동작하도록 정리했습니다.
- 카테고리 삭제 시 기존 깊은생각의 `category_id`를 먼저 비워 삭제 동기화가 깨지지 않도록 했습니다.

## 🛠️ 테스트 계획 및 결과
- [ ] docker build 완료 (docker-compose up --build )
- [ ] API 테스트(Postman/Swagger) 완료

## 📚 체크리스트
- [ ] 브랜치 전략에 맞는 브랜치인가요? (`[이름]/[타입]/[기능]`)
- [ ] 커밋 메시지 컨벤션을 준수했나요? (`[타입] 제목`)
- [ ] 불필요한 주석이나 print문은 제거했나요?

## 스크린샷 (선택)
<img width="619" height="463" alt="image" src="https://github.com/user-attachments/assets/86ff63fb-c321-4b95-8668-4c4875f07745" />


## 💬 리뷰어에게 (선택)