### PR TITLE
feat: 구글 소셜 로그인 및 연결 계정 API

### DIFF
--- a/src/main/java/com/afternote/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/afternote/domain/auth/controller/AuthController.java
@@ -98,10 +98,18 @@ public class AuthController {
             - refreshToken: 서비스 JWT Refresh Token
             - isNewUser: 신규 회원 여부 (true/false)
             
-            **예시:**
+            **예시 (카카오):**
             ```json
             {
               "provider": "KAKAO",
+              "accessToken": "카카오_액세스_토큰"
+            }
+            ```
+            
+            **예시 (구글):** 클라이언트는 Google Sign-In으로 받은 OAuth2 access token을 넘깁니다. `email` 스코프가 포함되어야 합니다.
+            ```json
+            {
+              "provider": "GOOGLE",
               "accessToken": "ya29.a0AfH6..."
             }
             ```

--- a/src/main/java/com/afternote/domain/auth/service/social/GoogleLoginService.java
+++ b/src/main/java/com/afternote/domain/auth/service/social/GoogleLoginService.java
@@ -1,0 +1,108 @@
+package com.afternote.domain.auth.service.social;
+
+import com.afternote.domain.auth.dto.SocialUserInfo;
+import com.afternote.domain.user.model.AuthProvider;
+import com.afternote.global.exception.CustomException;
+import com.afternote.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 구글 소셜 로그인 구현체.
+ * 클라이언트가 받은 Google OAuth2 access token으로 userinfo를 조회합니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoogleLoginService implements SocialLoginService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${google.oauth2.user-info-url}")
+    private String googleUserInfoUrl;
+
+    @Override
+    public SocialUserInfo getUserInfo(String accessToken) {
+        try {
+            log.debug(
+                    "Google userinfo request, token prefix: {}...",
+                    accessToken.substring(0, Math.min(20, accessToken.length()))
+            );
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(accessToken);
+            headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    googleUserInfoUrl,
+                    HttpMethod.GET,
+                    entity,
+                    Map.class
+            );
+
+            Map<String, Object> body = response.getBody();
+            if (body == null || body.isEmpty()) {
+                log.error("Google userinfo response body is empty");
+                throw new CustomException(ErrorCode.SOCIAL_LOGIN_FAILED);
+            }
+
+            String sub = stringValue(body.get("sub"));
+            if (sub == null || sub.isBlank()) {
+                log.error("Google userinfo missing sub: {}", body);
+                throw new CustomException(ErrorCode.SOCIAL_LOGIN_FAILED);
+            }
+
+            String email = stringValue(body.get("email"));
+            if (email == null || email.isBlank()) {
+                log.error("Google userinfo missing email (ensure email scope): {}", body);
+                throw new CustomException(ErrorCode.SOCIAL_LOGIN_FAILED);
+            }
+
+            String name = stringValue(body.get("name"));
+            if (name == null || name.isBlank()) {
+                name = email;
+            }
+
+            String picture = stringValue(body.get("picture"));
+
+            return SocialUserInfo.builder()
+                    .providerId(sub)
+                    .email(email)
+                    .name(name)
+                    .provider(AuthProvider.GOOGLE)
+                    .profileImageUrl(picture)
+                    .build();
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Google userinfo failed: {} - {}", e.getClass().getSimpleName(), e.getMessage(), e);
+            throw new CustomException(ErrorCode.SOCIAL_LOGIN_FAILED);
+        }
+    }
+
+    private static String stringValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String s = String.valueOf(value).trim();
+        return s.isEmpty() ? null : s;
+    }
+
+    @Override
+    public String getProviderName() {
+        return "GOOGLE";
+    }
+}

--- a/src/main/java/com/afternote/domain/user/controller/UserController.java
+++ b/src/main/java/com/afternote/domain/user/controller/UserController.java
@@ -75,6 +75,42 @@ public class UserController {
     }
 
     @Operation(
+            summary = "연결 계정 추가(소셜 연동) API",
+            description = """
+                    로그인한 사용자에게 소셜 제공자를 추가로 연결합니다.
+                    클라이언트는 해당 제공자 SDK로 받은 OAuth2 access token을 전달합니다.
+                    provider: KAKAO, GOOGLE, NAVER, APPLE (구현된 제공자만 성공)
+                    """
+    )
+    @PostMapping("/connected-accounts/{provider}")
+    public ApiResponse<UserConnectedAccountResponse> linkConnectedAccount(
+            @Parameter(hidden = true) @UserId Long userId,
+            @PathVariable String provider,
+            @Valid @RequestBody SocialAccountLinkRequest request
+    ) {
+        return ApiResponse.success(
+                userService.linkConnectedAccount(userId, provider, request)
+        );
+    }
+
+    @Operation(
+            summary = "연결 계정 해제 API",
+            description = """
+                    연결된 소셜 제공자 연동을 해제합니다. LOCAL(이메일 가입)은 해제할 수 없습니다.
+                    비밀번호가 없는 순수 소셜 계정은 마지막 남은 로그인 수단을 해제할 수 없습니다.
+                    """
+    )
+    @DeleteMapping("/connected-accounts/{provider}")
+    public ApiResponse<UserConnectedAccountResponse> unlinkConnectedAccount(
+            @Parameter(hidden = true) @UserId Long userId,
+            @PathVariable String provider
+    ) {
+        return ApiResponse.success(
+                userService.unlinkConnectedAccount(userId, provider)
+        );
+    }
+
+    @Operation(
             summary = "푸시 알림 설정 수정 API",
             description = "로그인한 사용자의 푸시 알림 수신 설정을 수정합니다."
     )

--- a/src/main/java/com/afternote/domain/user/dto/SocialAccountLinkRequest.java
+++ b/src/main/java/com/afternote/domain/user/dto/SocialAccountLinkRequest.java
@@ -1,0 +1,15 @@
+package com.afternote.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SocialAccountLinkRequest {
+
+    @Schema(description = "소셜 제공자에서 발급한 OAuth2 Access Token", example = "ya29.a0AfH6...")
+    @NotBlank(message = "Access Token을 입력해주세요.")
+    private String accessToken;
+}

--- a/src/main/java/com/afternote/domain/user/dto/UserConnectedAccountResponse.java
+++ b/src/main/java/com/afternote/domain/user/dto/UserConnectedAccountResponse.java
@@ -1,12 +1,15 @@
 package com.afternote.domain.user.dto;
 
+import com.afternote.domain.user.model.AuthProvider;
+import com.afternote.domain.user.model.User;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
+@Builder
 public class UserConnectedAccountResponse {
+
     @Schema(description = "일반(로컬) 계정 연결 여부", example = "true")
     private boolean local;
 
@@ -21,4 +24,41 @@ public class UserConnectedAccountResponse {
 
     @Schema(description = "애플 계정 연결 여부", example = "false")
     private boolean apple;
+
+    @Schema(description = "로컬(이메일)로 표시할 주소. 연결된 경우에만 채움", nullable = true)
+    private String localEmail;
+
+    @Schema(description = "구글 연동 시 UI에 표시할 이메일(현재 계정 이메일과 동일)", nullable = true)
+    private String googleEmail;
+
+    @Schema(description = "네이버 연동 시 UI에 표시할 이메일", nullable = true)
+    private String naverEmail;
+
+    @Schema(description = "카카오 연동 시 UI에 표시할 이메일", nullable = true)
+    private String kakaoEmail;
+
+    @Schema(description = "애플 연동 시 UI에 표시할 이메일", nullable = true)
+    private String appleEmail;
+
+    public static UserConnectedAccountResponse from(User user) {
+        String email = user.getEmail();
+        boolean local = user.hasProvider(AuthProvider.LOCAL);
+        boolean google = user.hasProvider(AuthProvider.GOOGLE);
+        boolean naver = user.hasProvider(AuthProvider.NAVER);
+        boolean kakao = user.hasProvider(AuthProvider.KAKAO);
+        boolean apple = user.hasProvider(AuthProvider.APPLE);
+
+        return UserConnectedAccountResponse.builder()
+                .local(local)
+                .google(google)
+                .naver(naver)
+                .kakao(kakao)
+                .apple(apple)
+                .localEmail(local ? email : null)
+                .googleEmail(google ? email : null)
+                .naverEmail(naver ? email : null)
+                .kakaoEmail(kakao ? email : null)
+                .appleEmail(apple ? email : null)
+                .build();
+    }
 }

--- a/src/main/java/com/afternote/domain/user/model/AuthProvider.java
+++ b/src/main/java/com/afternote/domain/user/model/AuthProvider.java
@@ -9,5 +9,6 @@ public enum AuthProvider {
     LOCAL,   // 일반 회원가입
     KAKAO,   // 카카오 로그인
     GOOGLE,  // 구글 로그인
-    NAVER    // 네이버 로그인 (향후 추가 예정)
+    NAVER,   // 네이버 로그인
+    APPLE    // 애플 로그인
 }

--- a/src/main/java/com/afternote/domain/user/model/User.java
+++ b/src/main/java/com/afternote/domain/user/model/User.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -235,5 +236,29 @@ public class User extends BaseEntity {
         return this.providers.stream()
                 .map(UserProvider::getProvider)
                 .collect(Collectors.toSet());
+    }
+
+    public Optional<String> getLinkedProviderId(AuthProvider provider) {
+        return this.providers.stream()
+                .filter(p -> p.getProvider() == provider)
+                .map(UserProvider::getProviderId)
+                .findFirst();
+    }
+
+    public int getProviderLinkCount() {
+        return this.providers.size();
+    }
+
+    /**
+     * 소셜 제공자 연결 해제. LOCAL은 해제할 수 없습니다.
+     */
+    public void removeProvider(AuthProvider provider) {
+        if (provider == null || provider == AuthProvider.LOCAL) {
+            throw new CustomException(ErrorCode.CANNOT_UNLINK_LOCAL_PROVIDER);
+        }
+        boolean removed = this.providers.removeIf(p -> p.getProvider() == provider);
+        if (!removed) {
+            throw new CustomException(ErrorCode.PROVIDER_NOT_CONNECTED);
+        }
     }
 }

--- a/src/main/java/com/afternote/domain/user/repository/UserProviderRepository.java
+++ b/src/main/java/com/afternote/domain/user/repository/UserProviderRepository.java
@@ -1,0 +1,15 @@
+package com.afternote.domain.user.repository;
+
+import com.afternote.domain.user.model.AuthProvider;
+import com.afternote.domain.user.model.UserProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserProviderRepository extends JpaRepository<UserProvider, Long> {
+
+    Optional<UserProvider> findByProviderAndProviderId(AuthProvider provider, String providerId);
+}
+ 

--- a/src/main/java/com/afternote/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/afternote/domain/user/repository/UserRepository.java
@@ -3,6 +3,8 @@ package com.afternote.domain.user.repository;
 import com.afternote.domain.user.model.User;
 import com.afternote.domain.user.model.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -22,5 +24,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     
     // 이름으로 사용자 검색 (부분 일치)
     List<User> findByNameContaining(String name);
-    
+
+    @Query("SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.providers WHERE u.id = :id")
+    Optional<User> findWithProvidersById(@Param("id") Long id);
+
 }

--- a/src/main/java/com/afternote/domain/user/service/UserService.java
+++ b/src/main/java/com/afternote/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.afternote.domain.user.service;
 
+import com.afternote.domain.auth.dto.SocialUserInfo;
+import com.afternote.domain.auth.service.social.SocialLoginFactory;
 import com.afternote.domain.image.service.S3Service;
 import com.afternote.domain.receiver.model.Receiver;
 import com.afternote.domain.receiver.model.UserReceiver;
@@ -10,6 +12,8 @@ import com.afternote.domain.user.dto.*;
 import com.afternote.domain.user.model.AuthProvider;
 import com.afternote.domain.user.model.DeliveryConditionType;
 import com.afternote.domain.user.model.User;
+import com.afternote.domain.user.model.UserProvider;
+import com.afternote.domain.user.repository.UserProviderRepository;
 import com.afternote.domain.user.repository.UserRepository;
 import com.afternote.domain.receiver.service.AuthCodeMessageService;
 import com.afternote.global.exception.CustomException;
@@ -20,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -33,6 +38,8 @@ public class UserService {
     private final S3Service s3Service;
     private final DeliveryVerificationService deliveryVerificationService;
     private final com.afternote.domain.auth.service.TokenService tokenService;
+    private final SocialLoginFactory socialLoginFactory;
+    private final UserProviderRepository userProviderRepository;
 
     public UserResponse getMyProfile(Long userId) {
 
@@ -68,15 +75,65 @@ public class UserService {
     }
 
     public UserConnectedAccountResponse getConnectedAccounts(Long userId) {
-        User user = findUserById(userId);
+        User user = findUserByIdWithProviders(userId);
+        return UserConnectedAccountResponse.from(user);
+    }
 
-        boolean local = user.hasProvider(AuthProvider.LOCAL);
-        boolean google = user.hasProvider(AuthProvider.GOOGLE);
-        boolean naver = user.hasProvider(AuthProvider.NAVER);
-        boolean kakao = user.hasProvider(AuthProvider.KAKAO);
-        boolean apple = false;
+    @Transactional
+    public UserConnectedAccountResponse linkConnectedAccount(
+            Long userId,
+            String providerPath,
+            SocialAccountLinkRequest request
+    ) {
+        AuthProvider authProvider = parseLinkableProvider(providerPath);
+        SocialUserInfo info = socialLoginFactory
+                .getService(authProvider.name())
+                .getUserInfo(request.getAccessToken());
 
-        return new UserConnectedAccountResponse(local, google, naver, kakao, apple);
+        if (info.getProviderId() == null || info.getProviderId().isBlank()) {
+            throw new CustomException(ErrorCode.SOCIAL_LOGIN_FAILED);
+        }
+
+        User user = findUserByIdWithProviders(userId);
+
+        Optional<UserProvider> existingGlobal = userProviderRepository
+                .findByProviderAndProviderId(authProvider, info.getProviderId());
+        if (existingGlobal.isPresent()) {
+            User owner = existingGlobal.get().getUser();
+            if (!owner.getId().equals(userId)) {
+                throw new CustomException(ErrorCode.SOCIAL_ACCOUNT_LINKED_TO_OTHER_USER);
+            }
+            return UserConnectedAccountResponse.from(user);
+        }
+
+        if (user.hasProvider(authProvider)) {
+            user.getLinkedProviderId(authProvider).ifPresent(existingId -> {
+                if (existingId != null && !existingId.isBlank()
+                        && !existingId.equals(info.getProviderId())) {
+                    throw new CustomException(ErrorCode.PROVIDER_ALREADY_CONNECTED_OTHER_ACCOUNT);
+                }
+            });
+        }
+
+        user.addProvider(authProvider, info.getProviderId());
+        return UserConnectedAccountResponse.from(user);
+    }
+
+    @Transactional
+    public UserConnectedAccountResponse unlinkConnectedAccount(Long userId, String providerPath) {
+        AuthProvider authProvider = parseUnlinkableProvider(providerPath);
+        User user = findUserByIdWithProviders(userId);
+
+        if (!user.hasProvider(authProvider)) {
+            throw new CustomException(ErrorCode.PROVIDER_NOT_CONNECTED);
+        }
+
+        if (user.getPassword() == null && user.getProviderLinkCount() <= 1) {
+            throw new CustomException(ErrorCode.CANNOT_UNLINK_LAST_CREDENTIAL);
+        }
+
+        user.removeProvider(authProvider);
+        return UserConnectedAccountResponse.from(user);
     }
 
     @Transactional
@@ -112,7 +169,6 @@ public class UserService {
 
         Receiver receiver = userReceiver.getReceiver();
 
-        // TODO: DailyQuestion, TimeLetter, AfterNote 도메인 생성 후 count 로직 추가
         int dailyCount = 0;
         int timeLetterCount = 0;
         int afterNoteCount = 0;
@@ -211,6 +267,37 @@ public class UserService {
     private User findUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private User findUserByIdWithProviders(Long userId) {
+        return userRepository.findWithProvidersById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private static AuthProvider parseLinkableProvider(String raw) {
+        AuthProvider provider;
+        try {
+            provider = AuthProvider.valueOf(raw.toUpperCase().trim());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_CONNECTED_ACCOUNT_PROVIDER);
+        }
+        if (provider == AuthProvider.LOCAL) {
+            throw new CustomException(ErrorCode.INVALID_CONNECTED_ACCOUNT_PROVIDER);
+        }
+        return provider;
+    }
+
+    private static AuthProvider parseUnlinkableProvider(String raw) {
+        AuthProvider provider;
+        try {
+            provider = AuthProvider.valueOf(raw.toUpperCase().trim());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_CONNECTED_ACCOUNT_PROVIDER);
+        }
+        if (provider == AuthProvider.LOCAL) {
+            throw new CustomException(ErrorCode.CANNOT_UNLINK_LOCAL_PROVIDER);
+        }
+        return provider;
     }
 
     @Transactional

--- a/src/main/java/com/afternote/global/exception/ErrorCode.java
+++ b/src/main/java/com/afternote/global/exception/ErrorCode.java
@@ -80,6 +80,15 @@ public enum ErrorCode {
     // 지원하지 않는 소셜 로그인 제공자
     UNSUPPORTED_SOCIAL_LOGIN(HttpStatus.BAD_REQUEST, 1209, "지원하지 않는 소셜 로그인 제공자입니다."),
 
+    // 연결 계정(소셜 연동)
+    SOCIAL_ACCOUNT_EMAIL_MISMATCH(HttpStatus.BAD_REQUEST, 1210, "소셜 계정 이메일이 현재 계정과 일치하지 않습니다."),
+    SOCIAL_ACCOUNT_LINKED_TO_OTHER_USER(HttpStatus.CONFLICT, 1211, "해당 소셜 계정은 이미 다른 사용자에게 연결되어 있습니다."),
+    PROVIDER_ALREADY_CONNECTED_OTHER_ACCOUNT(HttpStatus.CONFLICT, 1212, "이미 다른 소셜 계정이 이 제공자에 연결되어 있습니다."),
+    CANNOT_UNLINK_LAST_CREDENTIAL(HttpStatus.BAD_REQUEST, 1213, "최소 한 가지 로그인 수단은 유지해야 합니다."),
+    CANNOT_UNLINK_LOCAL_PROVIDER(HttpStatus.BAD_REQUEST, 1214, "일반(이메일) 계정 연결은 이 방식으로 해제할 수 없습니다."),
+    PROVIDER_NOT_CONNECTED(HttpStatus.BAD_REQUEST, 1215, "연결되지 않은 제공자입니다."),
+    INVALID_CONNECTED_ACCOUNT_PROVIDER(HttpStatus.BAD_REQUEST, 1216, "연결할 수 없는 제공자입니다."),
+
     // ======================================
     // 4. 타임레터 관련 오류 (code: 1300 ~ 1399)
     // ======================================

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,10 @@ kakao:
   api:
     user-info-url: https://kapi.kakao.com/v2/user/me
 
+google:
+  oauth2:
+    user-info-url: https://www.googleapis.com/oauth2/v3/userinfo
+
 server:
   port: ${SERVER_PORT:8080}
 


### PR DESCRIPTION
## 📌 관련 이슈
close #25 

## ✨ 작업 내용
변경 요약
구글 소셜 로그인: GoogleLoginService 추가, application.yml에 google.oauth2.user-info-url 설정. POST /api/v1/auth/social/login에 provider: GOOGLE 사용 가능.
연결 계정
GET /api/v1/users/connected-accounts: 연동 여부 + UI용 *Email 필드(연동 시 서비스에 등록된 user.email 기준).
POST /api/v1/users/connected-accounts/{provider}: Body에 소셜 accessToken으로 연동 추가. provider는 KAKAO, GOOGLE, NAVER, APPLE(서버에 구현된 제공자만 성공). LOCAL 불가.
DELETE /api/v1/users/connected-accounts/{provider}: 소셜 연동 해제. LOCAL 불가, 비밀번호 없는 계정은 마지막 로그인 수단 해제 불가.
도메인: AuthProvider에 APPLE 추가. User에 연동 해제·providerId 조회 등 보조 메서드 추가. UserProviderRepository, UserRepository.findWithProvidersById로 연동 조회/변경 시 로딩 정리.
에러 코드: 연동·해제용 코드 1210~1215 추가.
문서: AuthController 소셜 로그인 설명에 구글 예시 보강. UserController 연동 API에 경로 변수 provider 스웨거 @Parameter 설명 추가.

## 🛠️ 테스트 계획 및 결과
- [ ] docker build 완료 (docker-compose up --build )
- [ ] API 테스트(Postman/Swagger) 완료

## 📚 체크리스트
- [ ] 브랜치 전략에 맞는 브랜치인가요? (`[이름]/[타입]/[기능]`)
- [ ] 커밋 메시지 컨벤션을 준수했나요? (`[타입] 제목`)
- [ ] 불필요한 주석이나 print문은 제거했나요?

## 스크린샷 (선택)


## 💬 리뷰어에게 (선택)