### PR TITLE
fix: 깊은생각 태그 집계·diary 주간 평균 반영

### DIFF
--- a/src/main/java/com/afternote/domain/deepthought/controller/DeepThoughtController.java
+++ b/src/main/java/com/afternote/domain/deepthought/controller/DeepThoughtController.java
@@ -39,7 +39,8 @@ public class DeepThoughtController {
         return ApiResponse.success(deepThoughtService.createDeepThought(userId, request));
     }
 
-    @Operation(summary = "깊은 생각 조회", description = "날짜/태그/카테고리 조건으로 깊은 생각을 조회합니다. draftOnly=true이면 임시저장만 반환합니다.")
+    @Operation(summary = "깊은 생각 조회", description = "날짜/태그/카테고리 조건으로 깊은 생각을 조회합니다. draftOnly=true이면 임시저장만 반환합니다. "
+            + "응답의 tagCounts에는 동일한 날짜·카테고리·draftOnly 범위에서 태그별 글 개수가 포함되며, 목록 필터용 tag 검색어는 집계에 반영하지 않습니다.")
     @GetMapping
     public ApiResponse<DeepThoughtListResponse> getDeepThoughts(
             @Parameter(hidden = true) @UserId Long userId,

--- a/src/main/java/com/afternote/domain/deepthought/dto/DeepThoughtListResponse.java
+++ b/src/main/java/com/afternote/domain/deepthought/dto/DeepThoughtListResponse.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Collections;
 import java.util.List;
 
 @Getter
@@ -14,9 +15,20 @@ public class DeepThoughtListResponse {
     @Schema(description = "깊은 생각 목록")
     private List<DeepThoughtResponse> deepThoughts;
 
+    @Schema(description = "태그별 글 개수. 목록과 동일한 날짜·카테고리·draftOnly 조건이며, 태그 검색어(tag)는 적용하지 않음")
+    private List<DeepThoughtTagCountResponse> tagCounts;
+
     public static DeepThoughtListResponse from(List<DeepThoughtResponse> deepThoughts) {
+        return from(deepThoughts, Collections.emptyList());
+    }
+
+    public static DeepThoughtListResponse from(
+            List<DeepThoughtResponse> deepThoughts,
+            List<DeepThoughtTagCountResponse> tagCounts
+    ) {
         return DeepThoughtListResponse.builder()
                 .deepThoughts(deepThoughts)
+                .tagCounts(tagCounts)
                 .build();
     }
 }

--- a/src/main/java/com/afternote/domain/deepthought/dto/DeepThoughtTagCountResponse.java
+++ b/src/main/java/com/afternote/domain/deepthought/dto/DeepThoughtTagCountResponse.java
@@ -1,0 +1,20 @@
+package com.afternote.domain.deepthought.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "깊은 생각 태그별 개수")
+public class DeepThoughtTagCountResponse {
+
+    @Schema(description = "태그 이름", example = "성장")
+    private final String tag;
+
+    @Schema(description = "해당 태그가 붙은 깊은 생각 글 수(한 글에 같은 태그는 1회)", example = "3")
+    private final long count;
+
+    public DeepThoughtTagCountResponse(String tag, Long count) {
+        this.tag = tag;
+        this.count = count == null ? 0L : count;
+    }
+}

--- a/src/main/java/com/afternote/domain/deepthought/repository/DeepThoughtRepository.java
+++ b/src/main/java/com/afternote/domain/deepthought/repository/DeepThoughtRepository.java
@@ -1,5 +1,6 @@
 package com.afternote.domain.deepthought.repository;
 
+import com.afternote.domain.deepthought.dto.DeepThoughtTagCountResponse;
 import com.afternote.domain.deepthought.model.DeepThought;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -30,6 +31,23 @@ public interface DeepThoughtRepository extends JpaRepository<DeepThought, Long> 
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end,
             @Param("tag") String tag,
+            @Param("category") String category,
+            @Param("draftOnly") Boolean draftOnly
+    );
+
+    @Query("SELECT NEW com.afternote.domain.deepthought.dto.DeepThoughtTagCountResponse(t.title, COUNT(DISTINCT dt.id)) "
+            + "FROM DeepThought dt JOIN dt.tags t "
+            + "LEFT JOIN dt.category c "
+            + "WHERE dt.user.id = :userId "
+            + "AND (:start IS NULL OR (dt.createdAt >= :start AND dt.createdAt < :end)) "
+            + "AND (:category IS NULL OR c.title = :category) "
+            + "AND (:draftOnly IS NULL OR :draftOnly = false OR dt.isDraft = true) "
+            + "GROUP BY t.title "
+            + "ORDER BY COUNT(DISTINCT dt.id) DESC, t.title ASC")
+    List<DeepThoughtTagCountResponse> aggregateTagCounts(
+            @Param("userId") Long userId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
             @Param("category") String category,
             @Param("draftOnly") Boolean draftOnly
     );

--- a/src/main/java/com/afternote/domain/deepthought/service/DeepThoughtService.java
+++ b/src/main/java/com/afternote/domain/deepthought/service/DeepThoughtService.java
@@ -84,7 +84,10 @@ public class DeepThoughtService {
                 .map(DeepThoughtResponse::from)
                 .toList();
 
-        return DeepThoughtListResponse.from(list);
+        var tagCounts = deepThoughtRepository.aggregateTagCounts(
+                userId, start, end, normalizedCategory, draftOnly);
+
+        return DeepThoughtListResponse.from(list, tagCounts);
     }
 
     private String normalizeSearchParam(String value) {

--- a/src/main/java/com/afternote/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/afternote/domain/diary/controller/DiaryController.java
@@ -40,7 +40,8 @@ public class DiaryController {
         return ApiResponse.success(diaryService.createDiary(userId, request));
     }
 
-    @Operation(summary = "Diary 조회", description = "날짜 기준으로 다이어리를 조회합니다. draftOnly=true이면 해당 날짜의 임시저장만 반환합니다.")
+    @Operation(summary = "Diary 조회", description = "날짜 기준으로 다이어리를 조회합니다. draftOnly=true이면 해당 날짜의 임시저장만 반환합니다. "
+            + "응답에는 항상 이번 달 정식(비임시) 다이어리 개수(thisMonthDiaryCount)와 최근 7일 정식 다이어리 중 최빈 기분(weeklyDominantMood)이 포함됩니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Diary 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값이 올바르지 않음 (code: 1400)"),

--- a/src/main/java/com/afternote/domain/diary/dto/DiaryListResponse.java
+++ b/src/main/java/com/afternote/domain/diary/dto/DiaryListResponse.java
@@ -1,5 +1,6 @@
 package com.afternote.domain.diary.dto;
 
+import com.afternote.domain.diary.model.TodayMood;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,9 +15,25 @@ public class DiaryListResponse {
     @Schema(description = "다이어리 목록")
     private List<DiaryResponse> diaries;
 
+    @Schema(description = "이번 달 정식 등록(비임시) 다이어리 개수", example = "18")
+    private long thisMonthDiaryCount;
+
+    @Schema(description = "최근 7일(오늘 포함) 정식 다이어리 중 가장 많이 기록된 기분. 해당 구간에 기록이 없으면 null")
+    private TodayMood weeklyDominantMood;
+
     public static DiaryListResponse from(List<DiaryResponse> diaries) {
+        return from(diaries, 0L, null);
+    }
+
+    public static DiaryListResponse from(
+            List<DiaryResponse> diaries,
+            long thisMonthDiaryCount,
+            TodayMood weeklyDominantMood
+    ) {
         return DiaryListResponse.builder()
                 .diaries(diaries)
+                .thisMonthDiaryCount(thisMonthDiaryCount)
+                .weeklyDominantMood(weeklyDominantMood)
                 .build();
     }
 }

--- a/src/main/java/com/afternote/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/afternote/domain/diary/repository/DiaryRepository.java
@@ -1,7 +1,10 @@
 package com.afternote.domain.diary.repository;
 
 import com.afternote.domain.diary.model.Diary;
+import com.afternote.domain.diary.model.TodayMood;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -29,5 +32,19 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 			Long userId,
 			LocalDateTime startInclusive,
 			LocalDateTime endExclusive
+	);
+
+	long countByUserIdAndIsDraftFalseAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+			Long userId,
+			LocalDateTime startInclusive,
+			LocalDateTime endExclusive
+	);
+
+	@Query("SELECT d.todayMood FROM Diary d WHERE d.user.id = :userId AND d.isDraft = false "
+			+ "AND d.createdAt >= :startInclusive AND d.createdAt < :endExclusive")
+	List<TodayMood> findTodayMoodsByUserIdAndCreatedAtRange(
+			@Param("userId") Long userId,
+			@Param("startInclusive") LocalDateTime startInclusive,
+			@Param("endExclusive") LocalDateTime endExclusive
 	);
 }

--- a/src/main/java/com/afternote/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/afternote/domain/diary/service/DiaryService.java
@@ -5,6 +5,7 @@ import com.afternote.domain.diary.dto.DiaryListResponse;
 import com.afternote.domain.diary.dto.DiaryResponse;
 import com.afternote.domain.diary.dto.DiaryUpdateRequest;
 import com.afternote.domain.diary.model.Diary;
+import com.afternote.domain.diary.model.TodayMood;
 import com.afternote.domain.diary.repository.DiaryRepository;
 import com.afternote.domain.mindrecord.emotion.event.DiaryEmotionAnalysisRequestedEvent;
 import com.afternote.domain.user.model.User;
@@ -19,7 +20,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -65,7 +70,31 @@ public class DiaryService {
                 .map(DiaryResponse::from)
                 .toList();
 
-        return DiaryListResponse.from(responseList);
+        LocalDate today = LocalDate.now();
+        LocalDateTime monthStart = today.withDayOfMonth(1).atStartOfDay();
+        LocalDateTime monthEnd = today.plusMonths(1).withDayOfMonth(1).atStartOfDay();
+        long thisMonthCount = diaryRepository.countByUserIdAndIsDraftFalseAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+                userId, monthStart, monthEnd);
+
+        LocalDateTime weekStart = today.minusDays(6).atStartOfDay();
+        LocalDateTime weekEnd = today.plusDays(1).atStartOfDay();
+        List<TodayMood> weekMoods = diaryRepository.findTodayMoodsByUserIdAndCreatedAtRange(userId, weekStart, weekEnd);
+        TodayMood weeklyDominant = dominantMood(weekMoods);
+
+        return DiaryListResponse.from(responseList, thisMonthCount, weeklyDominant);
+    }
+
+    private static TodayMood dominantMood(List<TodayMood> moods) {
+        if (moods == null || moods.isEmpty()) {
+            return null;
+        }
+        return moods.stream()
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
+                .entrySet().stream()
+                .max(Comparator.<Map.Entry<TodayMood, Long>>comparingLong(Map.Entry::getValue)
+                        .thenComparing(e -> e.getKey().name()))
+                .map(Map.Entry::getKey)
+                .orElse(null);
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 관련 이슈
close #48

## ✨ 작업 내용
1. 깊은생각 목록 API — 태그 집계 (tagCounts)
GET /api/v1/deep-thought 응답의 data에 tagCounts 배열 추가.
각 항목: { "tag": "<태그명>", "count": <해당 태그가 붙은 글 수> } (한 글에 같은 태그는 1회로 집계).
정렬: 개수 내림차순, 동일하면 태그 이름 오름차순.
집계 범위: 목록과 동일한 날짜·카테고리·draftOnly 조건.
tag 쿼리 파라미터(검색)는 집계에는 적용하지 않음 — 특정 태그로 필터해도 칩/필터용 전체 분포를 볼 수 있도록.
구현: DeepThoughtRepository#aggregateTagCounts JPQL (GROUP BY + SELECT NEW → DeepThoughtTagCountResponse), DeepThoughtListResponse에 필드 추가.
2. 다이어리 목록 API — 카드용 요약 지표
GET /api/v1/diary 응답 data에 다음 필드 추가:
thisMonthDiaryCount: 이번 달(달력 기준 1일~다음 달 1일 전) 정식(비임시) 다이어리 개수.
weeklyDominantMood: 오늘 포함 최근 7일 정식 다이어리의 todayMood 중 가장 많이 기록된 값 (HAPPY / SOSO / SAD). 동률 시 태그명 사전순. 해당 구간에 기록이 없으면 null.
(이전 작업 포함 시) draftOnly 선택 파라미터: true면 해당 날짜 임시저장만 목록 조회.
위 월간/주간 지표는 항상 정식 글 기준으로 계산(목록 필터와 무관).
구현: DiaryRepository에 월간 count·주간 기분 조회 쿼리, DiaryService#getDiariesByDate에서 집계 후 DiaryListResponse에 포함.


## 🛠️ 테스트 계획 및 결과
- [ ] docker build 완료 (docker-compose up --build )
- [ ] API 테스트(Postman/Swagger) 완료

## 📚 체크리스트
- [ ] 브랜치 전략에 맞는 브랜치인가요? (`[이름]/[타입]/[기능]`)
- [ ] 커밋 메시지 컨벤션을 준수했나요? (`[타입] 제목`)
- [ ] 불필요한 주석이나 print문은 제거했나요?

## 스크린샷 (선택)


## 💬 리뷰어에게 (선택)