### PR TITLE
fix: 수신자 파트 프론트 요청사항 반영

### DIFF
--- a/src/main/java/com/afternote/domain/receiver/controller/ReceiverAuthController.java
+++ b/src/main/java/com/afternote/domain/receiver/controller/ReceiverAuthController.java
@@ -159,4 +159,30 @@ public class ReceiverAuthController {
                 )
         );
     }
+
+    @Operation(
+            summary = "받은 기록함 리스트 조회",
+            description = "수신자 접근 코드로 같은 이메일에 등록된 모든 받은 기록함 목록을 조회합니다."
+    )
+    @GetMapping("/record-boxes")
+    public ApiResponse<ReceivedRecordBoxListResponse> getReceivedRecordBoxes(
+            @Parameter(description = "수신자 접근 코드", required = true)
+            @RequestHeader("X-Auth-Code") String authCode
+    ) {
+        return ApiResponse.success(receiverAuthService.getReceivedRecordBoxes(authCode));
+    }
+
+    @Operation(
+            summary = "받은 기록함 단일 조회",
+            description = "수신자 접근 코드로 같은 이메일에 등록된 특정 받은 기록함을 조회합니다."
+    )
+    @GetMapping("/record-boxes/{receiverId}")
+    public ApiResponse<ReceivedRecordBoxResponse> getReceivedRecordBox(
+            @Parameter(description = "수신자 접근 코드", required = true)
+            @RequestHeader("X-Auth-Code") String authCode,
+            @Parameter(description = "조회할 수신자 ID", required = true)
+            @PathVariable Long receiverId
+    ) {
+        return ApiResponse.success(receiverAuthService.getReceivedRecordBox(authCode, receiverId));
+    }
 }

--- a/src/main/java/com/afternote/domain/receiver/controller/ReceiverAuthController.java
+++ b/src/main/java/com/afternote/domain/receiver/controller/ReceiverAuthController.java
@@ -131,4 +131,32 @@ public class ReceiverAuthController {
     ) {
         return ApiResponse.success(receiverAuthService.getDeliveryVerificationStatus(authCode));
     }
+
+    @Operation(
+            summary = "수신자 이메일 인증번호 발송",
+            description = "수신자 이메일로 6자리 인증번호를 발송합니다."
+    )
+    @PostMapping("/email/auth-code")
+    public ApiResponse<Void> sendEmailAuthCode(
+            @Valid @RequestBody ReceiverAuthCodeEmailSendRequest request
+    ) {
+        receiverAuthService.sendEmailAuthCode(request.getEmail());
+        return ApiResponse.success(null);
+    }
+
+    @Operation(
+            summary = "수신자 이메일 인증번호 검증",
+            description = "수신자가 입력한 6자리 이메일 인증번호를 검증하고, 콘텐츠 조회용 접근 코드를 반환합니다."
+    )
+    @PostMapping("/email/verify")
+    public ApiResponse<ReceiverEmailAuthVerifyResponse> verifyEmailAuthCode(
+            @Valid @RequestBody ReceiverEmailAuthVerifyRequest request
+    ) {
+        return ApiResponse.success(
+                receiverAuthService.verifyEmailAuthCode(
+                        request.getEmail(),
+                        request.getAuthCode()
+                )
+        );
+    }
 }

--- a/src/main/java/com/afternote/domain/receiver/dto/ReceivedRecordBoxListResponse.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/ReceivedRecordBoxListResponse.java
@@ -1,0 +1,16 @@
+package com.afternote.domain.receiver.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "받은 기록함 리스트 응답")
+public record ReceivedRecordBoxListResponse(
+
+        @Schema(description = "받은 기록함 목록")
+        List<ReceivedRecordBoxResponse> recordBoxes
+) {
+    public static ReceivedRecordBoxListResponse from(List<ReceivedRecordBoxResponse> recordBoxes) {
+        return new ReceivedRecordBoxListResponse(recordBoxes);
+    }
+}

--- a/src/main/java/com/afternote/domain/receiver/dto/ReceivedRecordBoxResponse.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/ReceivedRecordBoxResponse.java
@@ -1,0 +1,89 @@
+package com.afternote.domain.receiver.dto;
+
+import com.afternote.domain.receiver.model.DeliveryVerification;
+import com.afternote.domain.receiver.model.Receiver;
+import com.afternote.domain.receiver.model.ReceivedRecordStatus;
+import com.afternote.domain.receiver.model.VerificationStatus;
+import com.afternote.domain.user.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "받은 기록함 응답")
+public record ReceivedRecordBoxResponse(
+
+        @Schema(description = "수신자 ID", example = "1")
+        Long receiverId,
+
+        @Schema(description = "기록 열람 시 X-Auth-Code에 넣을 접근 코드", example = "550e8400-e29b-41d4-a716-446655440000")
+        String accessCode,
+
+        @Schema(description = "발신자 이름", example = "김혜성")
+        String senderName,
+
+        @Schema(description = "수신자 이름", example = "김지은")
+        String receiverName,
+
+        @Schema(description = "발신자와 수신자의 관계", example = "DAUGHTER")
+        String relation,
+
+        @Schema(description = "기록 보관 상태", example = "STORED")
+        ReceivedRecordStatus recordStatus,
+
+        @Schema(description = "열람 상태", example = "VIEWABLE")
+        String viewStatus,
+
+        @Schema(description = "서류 인증 상태", example = "PENDING")
+        String verificationStatus,
+
+        @Schema(description = "열람 신청일", example = "2026-05-03T10:30:00")
+        LocalDateTime requestedAt,
+
+        @Schema(description = "열람 승인일", example = "2026-05-03T14:20:00")
+        LocalDateTime approvedAt
+) {
+    public static ReceivedRecordBoxResponse from(
+            Receiver receiver,
+            User sender,
+            DeliveryVerification verification,
+            ReceivedRecordStatus recordStatus
+    ) {
+        String verificationStatus = verification != null
+                ? verification.getStatus().name()
+                : null;
+
+        LocalDateTime requestedAt = verification != null
+                ? verification.getCreatedAt()
+                : null;
+
+        LocalDateTime approvedAt = verification != null
+                && verification.getStatus() == VerificationStatus.APPROVED
+                ? verification.getUpdatedAt()
+                : null;
+
+        return new ReceivedRecordBoxResponse(
+                receiver.getId(),
+                receiver.getAuthCode(),
+                sender.getName(),
+                receiver.getName(),
+                receiver.getRelation(),
+                recordStatus,
+                determineViewStatus(sender, verification),
+                verificationStatus,
+                requestedAt,
+                approvedAt
+        );
+    }
+
+    private static String determineViewStatus(User sender, DeliveryVerification verification) {
+        if (sender.isDeliveryConditionMet()) {
+            return "VIEWABLE";
+        }
+
+        if (verification != null && verification.getStatus() == VerificationStatus.PENDING) {
+            return "PENDING";
+        }
+
+        return "REQUESTABLE";
+    }
+}

--- a/src/main/java/com/afternote/domain/receiver/dto/ReceiverAuthCodeEmailSendRequest.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/ReceiverAuthCodeEmailSendRequest.java
@@ -1,0 +1,15 @@
+package com.afternote.domain.receiver.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReceiverAuthCodeEmailSendRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/src/main/java/com/afternote/domain/receiver/dto/ReceiverEmailAuthVerifyRequest.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/ReceiverEmailAuthVerifyRequest.java
@@ -1,0 +1,20 @@
+package com.afternote.domain.receiver.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReceiverEmailAuthVerifyRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "인증번호는 필수입니다.")
+    @Pattern(regexp = "^[0-9]{6}$", message = "인증번호는 6자리 숫자여야 합니다.")
+    private String authCode;
+}

--- a/src/main/java/com/afternote/domain/receiver/dto/ReceiverEmailAuthVerifyResponse.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/ReceiverEmailAuthVerifyResponse.java
@@ -1,0 +1,28 @@
+package com.afternote.domain.receiver.dto;
+
+import com.afternote.domain.receiver.model.Receiver;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReceiverEmailAuthVerifyResponse {
+
+    private Long receiverId;
+    private String receiverName;
+    private String senderName;
+
+    /**
+     * 이후 X-Auth-Code 헤더에 넣을 UUID 접근 코드
+     */
+    private String accessCode;
+
+    public static ReceiverEmailAuthVerifyResponse from(Receiver receiver, String senderName) {
+        return new ReceiverEmailAuthVerifyResponse(
+                receiver.getId(),
+                receiver.getName(),
+                senderName,
+                receiver.getAuthCode()
+        );
+    }
+}

--- a/src/main/java/com/afternote/domain/receiver/model/ReceivedRecordStatus.java
+++ b/src/main/java/com/afternote/domain/receiver/model/ReceivedRecordStatus.java
@@ -1,0 +1,16 @@
+package com.afternote.domain.receiver.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "받은 기록함 보관 상태")
+public enum ReceivedRecordStatus {
+
+    @Schema(description = "보관 중")
+    STORED,
+
+    @Schema(description = "보관된 기록 없음")
+    EMPTY,
+
+    @Schema(description = "삭제됨")
+    DELETED
+}

--- a/src/main/java/com/afternote/domain/receiver/repository/AfternoteReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/AfternoteReceiverRepository.java
@@ -28,4 +28,6 @@ public interface AfternoteReceiverRepository extends JpaRepository<AfternoteRece
     Optional<AfternoteReceiver> findByAfternoteIdAndReceiverIdWithAfternote(
             @Param("afternoteId") Long afternoteId,
             @Param("receiverId") Long receiverId);
+
+    boolean existsByReceiverId(Long receiverId);
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/DeliveryVerificationRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/DeliveryVerificationRepository.java
@@ -22,4 +22,9 @@ public interface DeliveryVerificationRepository extends JpaRepository<DeliveryVe
     Optional<DeliveryVerification> findFirstByUserIdOrderByCreatedAtDesc(Long userId);
 
     boolean existsByUserIdAndReceiverIdAndStatus(Long userId, Long receiverId, VerificationStatus status);
+
+    Optional<DeliveryVerification> findFirstByUserIdAndReceiverIdOrderByCreatedAtDesc(
+            Long userId,
+            Long receiverId
+    );
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/ReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/ReceiverRepository.java
@@ -4,9 +4,11 @@ import com.afternote.domain.receiver.model.Receiver;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ReceiverRepository extends JpaRepository<Receiver, Long> {
     Optional<Receiver> findByAuthCode(String authCode);
+    Optional<Receiver> findFirstByEmailIgnoreCaseOrderByIdDesc(String email);
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/ReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/ReceiverRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 @Repository
 public interface ReceiverRepository extends JpaRepository<Receiver, Long> {
     Optional<Receiver> findByAuthCode(String authCode);
-    Optional<Receiver> findFirstByEmailIgnoreCaseOrderByIdDesc(String email);
+    List<Receiver> findAllByEmailIgnoreCaseOrderByIdDesc(String email);
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/TimeLetterReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/TimeLetterReceiverRepository.java
@@ -43,4 +43,6 @@ public interface TimeLetterReceiverRepository extends JpaRepository<TimeLetterRe
     void deleteByTimeLetterId(Long timeLetterId);
 
     void deleteByTimeLetterIdIn(List<Long> timeLetterIds);
+
+    boolean existsByReceiverId(Long receiverId);
 }

--- a/src/main/java/com/afternote/domain/receiver/service/ReceiverAuthService.java
+++ b/src/main/java/com/afternote/domain/receiver/service/ReceiverAuthService.java
@@ -10,9 +10,12 @@ import com.afternote.domain.user.repository.UserRepository;
 import com.afternote.global.exception.CustomException;
 import com.afternote.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Pattern;
 
 @Service
@@ -22,12 +25,16 @@ public class ReceiverAuthService {
 
     private static final Pattern UUID_PATTERN =
             Pattern.compile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
+    private static final Duration EMAIL_AUTH_CODE_TTL = Duration.ofMinutes(5);
+    private static final String EMAIL_AUTH_CODE_PREFIX = "receiver:email-auth:";
 
     private final ReceiverRepository receiverRepository;
     private final UserRepository userRepository;
     private final ReceivedService receivedService;
     private final DeliveryVerificationService deliveryVerificationService;
     private final S3Service s3Service;
+    private final AuthCodeMessageService authCodeMessageService;
+    private final StringRedisTemplate stringRedisTemplate;
 
     public ReceiverAuthVerifyResponse verifyAuthCode(String authCode) {
         Receiver receiver = findReceiverByAuthCode(authCode);
@@ -109,5 +116,81 @@ public class ReceiverAuthService {
         if (!sender.isDeliveryConditionMet()) {
             throw new CustomException(ErrorCode.DELIVERY_CONDITION_NOT_MET);
         }
+    }
+
+    public void sendEmailAuthCode(String email) {
+        String normalizedEmail = normalizeEmail(email);
+
+        Receiver receiver = receiverRepository.findFirstByEmailIgnoreCaseOrderByIdDesc(normalizedEmail)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECEIVER_EMAIL_NOT_FOUND));
+
+        User sender = userRepository.findById(receiver.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        String emailAuthCode = generateSixDigitCode();
+
+        String redisKey = EMAIL_AUTH_CODE_PREFIX + normalizedEmail;
+        String redisValue = receiver.getId() + ":" + emailAuthCode;
+
+        try {
+            stringRedisTemplate.opsForValue().set(
+                    redisKey,
+                    redisValue,
+                    EMAIL_AUTH_CODE_TTL
+            );
+
+            authCodeMessageService.sendAuthCode(
+                    receiver.getEmail(),
+                    emailAuthCode,
+                    sender.getName(),
+                    receiver.getName()
+            );
+        } catch (Exception e) {
+            stringRedisTemplate.delete(redisKey);
+            throw new CustomException(ErrorCode.RECEIVER_EMAIL_SEND_FAILED);
+        }
+    }
+
+    public ReceiverEmailAuthVerifyResponse verifyEmailAuthCode(String email, String inputAuthCode) {
+        String normalizedEmail = normalizeEmail(email);
+        String redisKey = EMAIL_AUTH_CODE_PREFIX + normalizedEmail;
+
+        String savedValue = stringRedisTemplate.opsForValue().get(redisKey);
+
+        if (savedValue == null) {
+            throw new CustomException(ErrorCode.RECEIVER_EMAIL_AUTH_CODE_NOT_FOUND);
+        }
+
+        String[] values = savedValue.split(":");
+
+        if (values.length != 2) {
+            stringRedisTemplate.delete(redisKey);
+            throw new CustomException(ErrorCode.RECEIVER_EMAIL_AUTH_CODE_NOT_FOUND);
+        }
+
+        Long receiverId = Long.parseLong(values[0]);
+        String savedAuthCode = values[1];
+
+        if (!savedAuthCode.equals(inputAuthCode)) {
+            throw new CustomException(ErrorCode.RECEIVER_EMAIL_AUTH_CODE_MISMATCH);
+        }
+
+        Receiver receiver = receiverRepository.findById(receiverId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECEIVER_NOT_FOUND));
+
+        User sender = userRepository.findById(receiver.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        stringRedisTemplate.delete(redisKey);
+
+        return ReceiverEmailAuthVerifyResponse.from(receiver, sender.getName());
+    }
+
+    private String generateSixDigitCode() {
+        return String.valueOf(ThreadLocalRandom.current().nextInt(100000, 1000000));
+    }
+
+    private String normalizeEmail(String email) {
+        return email.trim().toLowerCase();
     }
 }

--- a/src/main/java/com/afternote/domain/receiver/service/ReceiverAuthService.java
+++ b/src/main/java/com/afternote/domain/receiver/service/ReceiverAuthService.java
@@ -3,8 +3,13 @@ package com.afternote.domain.receiver.service;
 import com.afternote.domain.image.dto.PresignedUrlResponse;
 import com.afternote.domain.image.service.S3Service;
 import com.afternote.domain.receiver.dto.*;
+import com.afternote.domain.receiver.model.DeliveryVerification;
+import com.afternote.domain.receiver.model.ReceivedRecordStatus;
 import com.afternote.domain.receiver.model.Receiver;
+import com.afternote.domain.receiver.repository.AfternoteReceiverRepository;
+import com.afternote.domain.receiver.repository.DeliveryVerificationRepository;
 import com.afternote.domain.receiver.repository.ReceiverRepository;
+import com.afternote.domain.receiver.repository.TimeLetterReceiverRepository;
 import com.afternote.domain.user.model.User;
 import com.afternote.domain.user.repository.UserRepository;
 import com.afternote.global.exception.CustomException;
@@ -15,8 +20,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +44,9 @@ public class ReceiverAuthService {
     private final S3Service s3Service;
     private final AuthCodeMessageService authCodeMessageService;
     private final StringRedisTemplate stringRedisTemplate;
+    private final DeliveryVerificationRepository deliveryVerificationRepository;
+    private final TimeLetterReceiverRepository timeLetterReceiverRepository;
+    private final AfternoteReceiverRepository afternoteReceiverRepository;
 
     public ReceiverAuthVerifyResponse verifyAuthCode(String authCode) {
         Receiver receiver = findReceiverByAuthCode(authCode);
@@ -121,8 +133,14 @@ public class ReceiverAuthService {
     public void sendEmailAuthCode(String email) {
         String normalizedEmail = normalizeEmail(email);
 
-        Receiver receiver = receiverRepository.findFirstByEmailIgnoreCaseOrderByIdDesc(normalizedEmail)
-                .orElseThrow(() -> new CustomException(ErrorCode.RECEIVER_EMAIL_NOT_FOUND));
+        List<Receiver> receivers =
+                receiverRepository.findAllByEmailIgnoreCaseOrderByIdDesc(normalizedEmail);
+
+        if (receivers.isEmpty()) {
+            throw new CustomException(ErrorCode.RECEIVER_EMAIL_NOT_FOUND);
+        }
+
+        Receiver receiver = receivers.get(0);
 
         User sender = userRepository.findById(receiver.getUserId())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -192,5 +210,86 @@ public class ReceiverAuthService {
 
     private String normalizeEmail(String email) {
         return email.trim().toLowerCase();
+    }
+
+    public ReceivedRecordBoxListResponse getReceivedRecordBoxes(String authCode) {
+        Receiver authenticatedReceiver = findReceiverByAuthCode(authCode);
+
+        String email = normalizeEmail(authenticatedReceiver.getEmail());
+
+        List<Receiver> receivers = receiverRepository.findAllByEmailIgnoreCaseOrderByIdDesc(email);
+
+        if (receivers.isEmpty()) {
+            throw new CustomException(ErrorCode.RECEIVER_NOT_FOUND);
+        }
+
+        Map<Long, User> senderMap = userRepository.findAllById(
+                        receivers.stream()
+                                .map(Receiver::getUserId)
+                                .collect(Collectors.toSet())
+                )
+                .stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        List<ReceivedRecordBoxResponse> responses = receivers.stream()
+                .map(receiver -> toReceivedRecordBoxResponse(receiver, senderMap))
+                .toList();
+
+        return ReceivedRecordBoxListResponse.from(responses);
+    }
+
+    public ReceivedRecordBoxResponse getReceivedRecordBox(String authCode, Long receiverId) {
+        Receiver authenticatedReceiver = findReceiverByAuthCode(authCode);
+
+        Receiver targetReceiver = receiverRepository.findById(receiverId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECEIVER_NOT_FOUND));
+
+        if (!normalizeEmail(authenticatedReceiver.getEmail()).equals(normalizeEmail(targetReceiver.getEmail()))) {
+            throw new CustomException(ErrorCode.NOT_ENOUGH_PERMISSION);
+        }
+
+        User sender = userRepository.findById(targetReceiver.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        DeliveryVerification verification = deliveryVerificationRepository
+                .findFirstByUserIdAndReceiverIdOrderByCreatedAtDesc(
+                        sender.getId(),
+                        targetReceiver.getId()
+                )
+                .orElse(null);
+
+        ReceivedRecordStatus recordStatus = determineRecordStatus(targetReceiver.getId());
+        return ReceivedRecordBoxResponse.from(targetReceiver, sender, verification, recordStatus);    }
+
+    private ReceivedRecordBoxResponse toReceivedRecordBoxResponse(
+            Receiver receiver,
+            Map<Long, User> senderMap
+    ) {
+        User sender = senderMap.get(receiver.getUserId());
+
+        if (sender == null) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        DeliveryVerification verification = deliveryVerificationRepository
+                .findFirstByUserIdAndReceiverIdOrderByCreatedAtDesc(
+                        sender.getId(),
+                        receiver.getId()
+                )
+                .orElse(null);
+
+        ReceivedRecordStatus recordStatus = determineRecordStatus(receiver.getId());
+        return ReceivedRecordBoxResponse.from(receiver, sender, verification, recordStatus);
+    }
+
+    private ReceivedRecordStatus determineRecordStatus(Long receiverId) {
+        boolean hasTimeLetter = timeLetterReceiverRepository.existsByReceiverId(receiverId);
+        boolean hasAfternote = afternoteReceiverRepository.existsByReceiverId(receiverId);
+
+        if (hasTimeLetter || hasAfternote) {
+            return ReceivedRecordStatus.STORED;
+        }
+
+        return ReceivedRecordStatus.EMPTY;
     }
 }

--- a/src/main/java/com/afternote/global/exception/ErrorCode.java
+++ b/src/main/java/com/afternote/global/exception/ErrorCode.java
@@ -163,6 +163,10 @@ public enum ErrorCode {
 
     //gemini api
     GEMINI_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 1901, "LLM API 가 실패하였습니다. 원인은 토큰 만료, 시간 초과 등이 있습니다."),
+    RECEIVER_EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, 1902, "등록된 수신자 이메일이 아닙니다."),
+    RECEIVER_EMAIL_AUTH_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, 1903, "인증번호가 만료되었거나 존재하지 않습니다. 다시 요청해주세요."),
+    RECEIVER_EMAIL_AUTH_CODE_MISMATCH(HttpStatus.BAD_REQUEST, 1904, "이메일 인증번호가 일치하지 않습니다."),
+    RECEIVER_EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 1905, "이메일 인증번호 발송에 실패했습니다."),
 
     // ======================================
     // 10. 전달 조건/인증 관련 오류 (code: 2000 ~ 2099)

--- a/src/main/resources/data-local.sql
+++ b/src/main/resources/data-local.sql
@@ -54,5 +54,5 @@ ALTER TABLE time_letter_receiver
 ALTER TABLE user_daily_question_receiver
     MODIFY COLUMN created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);
 
-ALTER TABLE time_letter_media
+ALTER TABLE time_letter_blocks
     MODIFY COLUMN created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);


### PR DESCRIPTION
## 📌 관련 이슈
close #56 

## ✨ 작업 내용
- 로컬 DB sql문 중 time_letter_media가 아니라 time_letter_block이라 수정했습니다.
- 수신자 이메일 인증번호 발송 및 검증 api 구현했습니다.
- 수신자 받은 기록함 목록 및 단일 조회 api 구현했습니다.

## 🛠️ 테스트 계획 및 결과
- [x] 로컬 API 테스트(Postman/Swagger) 완료
- [ ] API 테스트(Postman/Swagger) 완료

## 📚 체크리스트
- [x] 브랜치 전략에 맞는 브랜치인가요? (`[이름]/[타입]/[기능]`)
- [x] 커밋 메시지 컨벤션을 준수했나요? (`[타입] 제목`)
- [x] 불필요한 주석이나 print문은 제거했나요?

## 스크린샷 (선택)


## 💬 리뷰어에게 (선택)