### PR TITLE
fix: 마인드레코드 수신자 등록 API 변경

### DIFF
--- a/src/main/java/com/afternote/domain/dailyquestion/service/DailyQuestionService.java
+++ b/src/main/java/com/afternote/domain/dailyquestion/service/DailyQuestionService.java
@@ -6,6 +6,7 @@ import com.afternote.domain.dailyquestion.model.UserDailyQuestion;
 import com.afternote.domain.dailyquestion.repository.DailyQuestionRepository;
 import com.afternote.domain.dailyquestion.repository.UserDailyQuestionRepository;
 import com.afternote.domain.mindrecord.emotion.event.DailyQuestionEmotionAnalysisRequestedEvent;
+import com.afternote.domain.receiver.repository.UserDailyQuestionReceiverRepository;
 import com.afternote.domain.user.model.User;
 import com.afternote.domain.user.repository.UserRepository;
 import com.afternote.global.exception.CustomException;
@@ -33,6 +34,7 @@ public class DailyQuestionService {
     private final ApplicationEventPublisher eventPublisher;
     private final UserRepository userRepository;
     private final MindRecordHtmlSanitizer mindRecordHtmlSanitizer;
+    private final UserDailyQuestionReceiverRepository userDailyQuestionReceiverRepository;
 
     @Transactional
     public DailyQuestionTodayResponse getTodayQuestion(Long userId) {
@@ -176,6 +178,7 @@ public class DailyQuestionService {
             throw new CustomException(ErrorCode.NOT_ENOUGH_PERMISSION);
         }
 
+        userDailyQuestionReceiverRepository.deleteByUserDailyQuestionId(userDailyQuestionId);
         userDailyQuestionRepository.delete(userDailyQuestion);
     }
 }

--- a/src/main/java/com/afternote/domain/deepthought/service/DeepThoughtService.java
+++ b/src/main/java/com/afternote/domain/deepthought/service/DeepThoughtService.java
@@ -8,6 +8,7 @@ import com.afternote.domain.deepthought.model.DeepThoughtCategory;
 import com.afternote.domain.deepthought.repository.DeepThoughtCategoryRepository;
 import com.afternote.domain.deepthought.repository.DeepThoughtRepository;
 import com.afternote.domain.mindrecord.emotion.event.DeepThoughtEmotionAnalysisRequestedEvent;
+import com.afternote.domain.receiver.repository.DeepThoughtReceiverRepository;
 import com.afternote.domain.user.model.User;
 import com.afternote.domain.user.repository.UserRepository;
 import com.afternote.global.exception.CustomException;
@@ -32,6 +33,7 @@ public class DeepThoughtService {
     private final ApplicationEventPublisher eventPublisher;
     private final UserRepository userRepository;
     private final MindRecordHtmlSanitizer mindRecordHtmlSanitizer;
+    private final DeepThoughtReceiverRepository deepThoughtReceiverRepository;
 
     @Transactional
     public DeepThoughtResponse createDeepThought(Long userId, DeepThoughtCreateRequest request) {
@@ -114,6 +116,7 @@ public class DeepThoughtService {
     public void deleteDeepThought(Long userId, Long deepThoughtId) {
         DeepThought deepThought = deepThoughtRepository.findByIdAndUserId(deepThoughtId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.DEEP_THOUGHT_NOT_FOUND));
+        deepThoughtReceiverRepository.deleteByDeepThoughtId(deepThoughtId);
         deepThoughtRepository.delete(deepThought);
     }
 

--- a/src/main/java/com/afternote/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/afternote/domain/diary/service/DiaryService.java
@@ -8,6 +8,7 @@ import com.afternote.domain.diary.model.Diary;
 import com.afternote.domain.diary.model.TodayMood;
 import com.afternote.domain.diary.repository.DiaryRepository;
 import com.afternote.domain.mindrecord.emotion.event.DiaryEmotionAnalysisRequestedEvent;
+import com.afternote.domain.receiver.repository.DiaryReceiverRepository;
 import com.afternote.domain.user.model.User;
 import com.afternote.domain.user.repository.UserRepository;
 import com.afternote.global.exception.CustomException;
@@ -36,6 +37,7 @@ public class DiaryService {
     private final ApplicationEventPublisher eventPublisher;
     private final UserRepository userRepository;
     private final MindRecordHtmlSanitizer mindRecordHtmlSanitizer;
+    private final DiaryReceiverRepository diaryReceiverRepository;
 
     @Transactional
     public DiaryResponse createDiary(Long userId, DiaryCreateRequest request) {
@@ -119,6 +121,7 @@ public class DiaryService {
     public void deleteDiary(Long userId, Long diaryId) {
         Diary diary = diaryRepository.findByIdAndUserId(diaryId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
+        diaryReceiverRepository.deleteByDiaryId(diaryId);
         diaryRepository.delete(diary);
     }
 }

--- a/src/main/java/com/afternote/domain/receiver/controller/ReceivedController.java
+++ b/src/main/java/com/afternote/domain/receiver/controller/ReceivedController.java
@@ -32,4 +32,43 @@ public class ReceivedController {
     ) {
         return ApiResponse.success(receivedService.createTimeLetterReceivers(userId, request));
     }
+
+    @Operation(
+            summary = "깊은 생각 수신자 등록",
+            description = "깊은 생각에 수신자를 등록합니다. 여러 수신자를 한 번에 등록할 수 있습니다."
+    )
+    @PostMapping("/deep-thought")
+    public ApiResponse<Void> createDeepThoughtReceivers(
+            @Parameter(hidden = true) @UserId Long userId,
+            @Valid @RequestBody CreateDeepThoughtReceiverRequest request
+    ) {
+        receivedService.createDeepThoughtReceivers(userId, request);
+        return ApiResponse.success(null);
+    }
+
+    @Operation(
+            summary = "다이어리 수신자 등록",
+            description = "다이어리에 수신자를 등록합니다. 여러 수신자를 한 번에 등록할 수 있습니다."
+    )
+    @PostMapping("/diary")
+    public ApiResponse<Void> createDiaryReceivers(
+            @Parameter(hidden = true) @UserId Long userId,
+            @Valid @RequestBody CreateDiaryReceiverRequest request
+    ) {
+        receivedService.createDiaryReceivers(userId, request);
+        return ApiResponse.success(null);
+    }
+
+    @Operation(
+            summary = "데일리 질문 수신자 등록",
+            description = "데일리 질문 답변에 수신자를 등록합니다. 여러 수신자를 한 번에 등록할 수 있습니다."
+    )
+    @PostMapping("/daily-question")
+    public ApiResponse<Void> createUserDailyQuestionReceivers(
+            @Parameter(hidden = true) @UserId Long userId,
+            @Valid @RequestBody CreateUserDailyQuestionReceiverRequest request
+    ) {
+        receivedService.createUserDailyQuestionReceivers(userId, request);
+        return ApiResponse.success(null);
+    }
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/DeepThoughtReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/DeepThoughtReceiverRepository.java
@@ -4,6 +4,12 @@ import com.afternote.domain.receiver.model.DeepThoughtReceiver;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface DeepThoughtReceiverRepository extends JpaRepository<DeepThoughtReceiver, Long> {
+
+    List<DeepThoughtReceiver> findByDeepThoughtIdAndReceiverIdIn(Long deepThoughtId, List<Long> receiverIds);
+
+    void deleteByDeepThoughtId(Long deepThoughtId);
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/DiaryReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/DiaryReceiverRepository.java
@@ -4,6 +4,12 @@ import com.afternote.domain.receiver.model.DiaryReceiver;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface DiaryReceiverRepository extends JpaRepository<DiaryReceiver, Long> {
+
+    List<DiaryReceiver> findByDiaryIdAndReceiverIdIn(Long diaryId, List<Long> receiverIds);
+
+    void deleteByDiaryId(Long diaryId);
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/UserDailyQuestionReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/UserDailyQuestionReceiverRepository.java
@@ -4,6 +4,12 @@ import com.afternote.domain.receiver.model.UserDailyQuestionReceiver;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface UserDailyQuestionReceiverRepository extends JpaRepository<UserDailyQuestionReceiver, Long> {
+
+    List<UserDailyQuestionReceiver> findByUserDailyQuestionIdAndReceiverIdIn(Long userDailyQuestionId, List<Long> receiverIds);
+
+    void deleteByUserDailyQuestionId(Long userDailyQuestionId);
 }

--- a/src/main/java/com/afternote/domain/receiver/service/ReceivedService.java
+++ b/src/main/java/com/afternote/domain/receiver/service/ReceivedService.java
@@ -2,13 +2,25 @@ package com.afternote.domain.receiver.service;
 
 import com.afternote.domain.afternote.model.Afternote;
 import com.afternote.domain.afternote.model.AfternoteReceiver;
+import com.afternote.domain.dailyquestion.model.UserDailyQuestion;
+import com.afternote.domain.dailyquestion.repository.UserDailyQuestionRepository;
+import com.afternote.domain.deepthought.model.DeepThought;
+import com.afternote.domain.deepthought.repository.DeepThoughtRepository;
+import com.afternote.domain.diary.model.Diary;
+import com.afternote.domain.diary.repository.DiaryRepository;
 import com.afternote.domain.image.service.S3Service;
 import com.afternote.domain.receiver.dto.*;
+import com.afternote.domain.receiver.model.DeepThoughtReceiver;
+import com.afternote.domain.receiver.model.DiaryReceiver;
 import com.afternote.domain.receiver.model.Receiver;
 import com.afternote.domain.receiver.model.TimeLetterReceiver;
+import com.afternote.domain.receiver.model.UserDailyQuestionReceiver;
 import com.afternote.domain.receiver.repository.AfternoteReceiverRepository;
+import com.afternote.domain.receiver.repository.DeepThoughtReceiverRepository;
+import com.afternote.domain.receiver.repository.DiaryReceiverRepository;
 import com.afternote.domain.receiver.repository.ReceiverRepository;
 import com.afternote.domain.receiver.repository.TimeLetterReceiverRepository;
+import com.afternote.domain.receiver.repository.UserDailyQuestionReceiverRepository;
 import com.afternote.domain.timeletter.model.TimeLetter;
 import com.afternote.domain.timeletter.repository.TimeLetterRepository;
 import com.afternote.domain.user.model.User;
@@ -36,7 +48,13 @@ public class ReceivedService {
     private final ReceiverRepository receiverRepository;
     private final TimeLetterReceiverRepository timeLetterReceiverRepository;
     private final AfternoteReceiverRepository afternoteReceiverRepository;
+    private final DeepThoughtReceiverRepository deepThoughtReceiverRepository;
+    private final DiaryReceiverRepository diaryReceiverRepository;
+    private final UserDailyQuestionReceiverRepository userDailyQuestionReceiverRepository;
     private final TimeLetterRepository timeLetterRepository;
+    private final DeepThoughtRepository deepThoughtRepository;
+    private final DiaryRepository diaryRepository;
+    private final UserDailyQuestionRepository userDailyQuestionRepository;
     private final UserRepository userRepository;
     private final S3Service s3Service;
 
@@ -229,6 +247,94 @@ public class ReceivedService {
     }
 
     /**
+     * 깊은 생각에 수신자 등록
+     */
+    @Transactional
+    public List<Long> createDeepThoughtReceivers(Long userId, CreateDeepThoughtReceiverRequest request) {
+        DeepThought deepThought = deepThoughtRepository.findByIdAndUserId(request.getDeepThoughtId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DEEP_THOUGHT_NOT_FOUND));
+
+        List<Receiver> receivers = findOwnedReceivers(userId, request.getReceiverIds());
+        Set<Long> existingReceiverIds = deepThoughtReceiverRepository
+                .findByDeepThoughtIdAndReceiverIdIn(deepThought.getId(), toReceiverIds(receivers))
+                .stream()
+                .map(deepThoughtReceiver -> deepThoughtReceiver.getReceiver().getId())
+                .collect(Collectors.toSet());
+
+        List<DeepThoughtReceiver> deepThoughtReceivers = receivers.stream()
+                .filter(receiver -> !existingReceiverIds.contains(receiver.getId()))
+                .map(receiver -> DeepThoughtReceiver.builder()
+                        .deepThought(deepThought)
+                        .receiver(receiver)
+                        .build())
+                .toList();
+
+        return deepThoughtReceiverRepository.saveAll(deepThoughtReceivers).stream()
+                .map(DeepThoughtReceiver::getId)
+                .toList();
+    }
+
+    /**
+     * 다이어리에 수신자 등록
+     */
+    @Transactional
+    public List<Long> createDiaryReceivers(Long userId, CreateDiaryReceiverRequest request) {
+        Diary diary = diaryRepository.findByIdAndUserId(request.getDiaryId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
+
+        List<Receiver> receivers = findOwnedReceivers(userId, request.getReceiverIds());
+        Set<Long> existingReceiverIds = diaryReceiverRepository
+                .findByDiaryIdAndReceiverIdIn(diary.getId(), toReceiverIds(receivers))
+                .stream()
+                .map(diaryReceiver -> diaryReceiver.getReceiver().getId())
+                .collect(Collectors.toSet());
+
+        List<DiaryReceiver> diaryReceivers = receivers.stream()
+                .filter(receiver -> !existingReceiverIds.contains(receiver.getId()))
+                .map(receiver -> DiaryReceiver.builder()
+                        .diary(diary)
+                        .receiver(receiver)
+                        .build())
+                .toList();
+
+        return diaryReceiverRepository.saveAll(diaryReceivers).stream()
+                .map(DiaryReceiver::getId)
+                .toList();
+    }
+
+    /**
+     * 데일리 질문 답변에 수신자 등록
+     */
+    @Transactional
+    public List<Long> createUserDailyQuestionReceivers(Long userId, CreateUserDailyQuestionReceiverRequest request) {
+        UserDailyQuestion userDailyQuestion = userDailyQuestionRepository.findById(request.getUserDailyQuestionId())
+                .orElseThrow(() -> new CustomException(ErrorCode.DAILY_QUESTION_NOT_FOUND));
+
+        if (!userDailyQuestion.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.NOT_ENOUGH_PERMISSION);
+        }
+
+        List<Receiver> receivers = findOwnedReceivers(userId, request.getReceiverIds());
+        Set<Long> existingReceiverIds = userDailyQuestionReceiverRepository
+                .findByUserDailyQuestionIdAndReceiverIdIn(userDailyQuestion.getId(), toReceiverIds(receivers))
+                .stream()
+                .map(userDailyQuestionReceiver -> userDailyQuestionReceiver.getReceiver().getId())
+                .collect(Collectors.toSet());
+
+        List<UserDailyQuestionReceiver> userDailyQuestionReceivers = receivers.stream()
+                .filter(receiver -> !existingReceiverIds.contains(receiver.getId()))
+                .map(receiver -> UserDailyQuestionReceiver.builder()
+                        .userDailyQuestion(userDailyQuestion)
+                        .receiver(receiver)
+                        .build())
+                .toList();
+
+        return userDailyQuestionReceiverRepository.saveAll(userDailyQuestionReceivers).stream()
+                .map(UserDailyQuestionReceiver::getId)
+                .toList();
+    }
+
+    /**
      * 수신자 ID 목록 정규화
      * - null 또는 빈 목록이면 예외를 발생시킨다.
      * - null 원소를 제거한다.
@@ -250,6 +356,24 @@ public class ReceivedService {
         }
 
         return uniqueReceiverIds;
+    }
+
+    private List<Receiver> findOwnedReceivers(Long userId, List<Long> receiverIds) {
+        List<Long> uniqueReceiverIds = normalizeReceiverIds(receiverIds);
+
+        List<Receiver> receivers = receiverRepository.findAllById(uniqueReceiverIds);
+        if (receivers.size() != uniqueReceiverIds.size()) {
+            throw new CustomException(ErrorCode.RECEIVER_NOT_FOUND);
+        }
+
+        validateReceiversOwnership(userId, receivers);
+        return receivers;
+    }
+
+    private List<Long> toReceiverIds(List<Receiver> receivers) {
+        return receivers.stream()
+                .map(Receiver::getId)
+                .toList();
     }
 
     /**

--- a/src/test/java/com/afternote/domain/receiver/controller/ReceivedControllerTest.java
+++ b/src/test/java/com/afternote/domain/receiver/controller/ReceivedControllerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -69,6 +70,61 @@ class ReceivedControllerTest {
                         .requestAttr(UserIdArgumentResolver.USER_ID_ATTRIBUTE, USER_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"timeLetterID\":1}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("깊은 생각 수신자 등록 API 성공")
+    void createDeepThoughtReceivers_Success() throws Exception {
+        given(receivedService.createDeepThoughtReceivers(eq(USER_ID), any())).willReturn(List.of(1L, 2L));
+
+        mockMvc.perform(post("/api/v1/received/deep-thought")
+                        .requestAttr(UserIdArgumentResolver.USER_ID_ATTRIBUTE, USER_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"deepThoughtId\":1,\"receiverIds\":[1,2]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(receivedService).createDeepThoughtReceivers(eq(USER_ID), any());
+    }
+
+    @Test
+    @DisplayName("다이어리 수신자 등록 API 성공")
+    void createDiaryReceivers_Success() throws Exception {
+        given(receivedService.createDiaryReceivers(eq(USER_ID), any())).willReturn(List.of(1L, 2L));
+
+        mockMvc.perform(post("/api/v1/received/diary")
+                        .requestAttr(UserIdArgumentResolver.USER_ID_ATTRIBUTE, USER_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"diaryId\":1,\"receiverIds\":[1,2]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(receivedService).createDiaryReceivers(eq(USER_ID), any());
+    }
+
+    @Test
+    @DisplayName("데일리 질문 수신자 등록 API 성공")
+    void createUserDailyQuestionReceivers_Success() throws Exception {
+        given(receivedService.createUserDailyQuestionReceivers(eq(USER_ID), any())).willReturn(List.of(1L, 2L));
+
+        mockMvc.perform(post("/api/v1/received/daily-question")
+                        .requestAttr(UserIdArgumentResolver.USER_ID_ATTRIBUTE, USER_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userDailyQuestionId\":1,\"receiverIds\":[1,2]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(receivedService).createUserDailyQuestionReceivers(eq(USER_ID), any());
+    }
+
+    @Test
+    @DisplayName("다이어리 수신자 등록 API 실패 - receiverIds 누락")
+    void createDiaryReceivers_MissingReceiverIds_Fail() throws Exception {
+        mockMvc.perform(post("/api/v1/received/diary")
+                        .requestAttr(UserIdArgumentResolver.USER_ID_ATTRIBUTE, USER_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"diaryId\":1}"))
                 .andExpect(status().isBadRequest());
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
close #39

## ✨ 작업 내용
- 기존 마인레코드 수신자 등록 api를 깊은 생각/일기/데일리 질문 수신자 등록 api로 변경했습니다

## 🛠️ 테스트 계획 및 결과
- [x] 로컬 API 테스트(Postman/Swagger) 완료
- [ ] API 테스트(Postman/Swagger) 완료

## 📚 체크리스트
- [x] 브랜치 전략에 맞는 브랜치인가요? (`[이름]/[타입]/[기능]`)
- [x] 커밋 메시지 컨벤션을 준수했나요? (`[타입] 제목`)
- [x] 불필요한 주석이나 print문은 제거했나요?

## 스크린샷 (선택)


## 💬 리뷰어에게 (선택)