### PR TITLE
fix: 수신자 마인드레코드 조회 API 변경

### DIFF
--- a/src/main/java/com/afternote/domain/receiver/controller/ReceiverAuthController.java
+++ b/src/main/java/com/afternote/domain/receiver/controller/ReceiverAuthController.java
@@ -1,6 +1,7 @@
 package com.afternote.domain.receiver.controller;
 
 import com.afternote.domain.image.dto.PresignedUrlResponse;
+import com.afternote.domain.receiver.model.ReceivedRecordSort;
 import com.afternote.domain.receiver.dto.*;
 import com.afternote.domain.receiver.service.ReceiverAuthService;
 import com.afternote.global.common.ApiResponse;
@@ -10,6 +11,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.format.annotation.DateTimeFormat;
+import java.time.LocalDate;
 
 @Tag(name = "Receiver Auth API", description = "수신자 인증번호 기반 콘텐츠 조회 API")
 @RestController
@@ -80,6 +83,70 @@ public class ReceiverAuthController {
             @PathVariable Long afternoteId
     ) {
         return ApiResponse.success(receiverAuthService.getAfternoteByAuthCode(authCode, afternoteId));
+    }
+
+    @Operation(
+            summary = "수신자 일기 목록 조회",
+            description = "수신자 접근 코드로 해당 수신자에게 전달된 일기 목록을 조회합니다."
+    )
+    @GetMapping("/diary")
+    public ApiResponse<ReceivedDiaryListResponse> getReceivedDiaries(
+            @Parameter(description = "수신자 접근 코드", required = true)
+            @RequestHeader("X-Auth-Code") String authCode,
+            @Parameter(description = "정렬 기준: LATEST 또는 OLDEST")
+            @RequestParam(defaultValue = "LATEST") ReceivedRecordSort sort,
+            @Parameter(description = "조회 시작일", example = "2026-12-12")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @Parameter(description = "조회 종료일", example = "2026-12-16")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+        return ApiResponse.success(
+                receiverAuthService.getReceivedDiaries(authCode, sort, startDate, endDate)
+        );
+    }
+
+    @Operation(
+            summary = "수신자 깊은 생각 목록 조회",
+            description = "수신자 접근 코드로 해당 수신자에게 전달된 깊은 생각 목록을 조회합니다. 카테고리/태그/기간/정렬 필터를 지원합니다."
+    )
+    @GetMapping("/deep-thought")
+    public ApiResponse<ReceivedDeepThoughtListResponse> getReceivedDeepThoughts(
+            @Parameter(description = "수신자 접근 코드", required = true)
+            @RequestHeader("X-Auth-Code") String authCode,
+            @Parameter(description = "카테고리", example = "성장")
+            @RequestParam(required = false) String category,
+            @Parameter(description = "태그", example = "희망")
+            @RequestParam(required = false) String tag,
+            @Parameter(description = "정렬 기준: LATEST 또는 OLDEST")
+            @RequestParam(defaultValue = "LATEST") ReceivedRecordSort sort,
+            @Parameter(description = "조회 시작일", example = "2026-12-12")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @Parameter(description = "조회 종료일", example = "2026-12-16")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+        return ApiResponse.success(
+                receiverAuthService.getReceivedDeepThoughts(authCode, category, tag, sort, startDate, endDate)
+        );
+    }
+
+    @Operation(
+            summary = "수신자 데일리 질문 답변 목록 조회",
+            description = "수신자 접근 코드로 해당 수신자에게 전달된 데일리 질문 답변 목록을 조회합니다."
+    )
+    @GetMapping("/daily-question")
+    public ApiResponse<ReceivedDailyQuestionListResponse> getReceivedDailyQuestions(
+            @Parameter(description = "수신자 접근 코드", required = true)
+            @RequestHeader("X-Auth-Code") String authCode,
+            @Parameter(description = "정렬 기준: LATEST 또는 OLDEST")
+            @RequestParam(defaultValue = "LATEST") ReceivedRecordSort sort,
+            @Parameter(description = "조회 시작일", example = "2026-12-12")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @Parameter(description = "조회 종료일", example = "2026-12-16")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+        return ApiResponse.success(
+                receiverAuthService.getReceivedDailyQuestions(authCode, sort, startDate, endDate)
+        );
     }
 
     @Operation(

--- a/src/main/java/com/afternote/domain/receiver/dto/CreateDeepThoughtReceiverRequest.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/CreateDeepThoughtReceiverRequest.java
@@ -1,0 +1,25 @@
+package com.afternote.domain.receiver.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Schema(description = "깊은 생각 수신자 등록 요청")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateDeepThoughtReceiverRequest {
+
+    @NotNull(message = "깊은 생각 ID는 필수입니다.")
+    @Schema(description = "깊은 생각 ID", example = "1")
+    private Long deepThoughtId;
+
+    @NotEmpty(message = "수신자 ID 목록은 필수입니다.")
+    @Schema(description = "수신자 ID 목록", example = "[1, 2, 3]")
+    private List<Long> receiverIds;
+}

--- a/src/main/java/com/afternote/domain/receiver/dto/CreateDiaryReceiverRequest.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/CreateDiaryReceiverRequest.java
@@ -1,0 +1,25 @@
+package com.afternote.domain.receiver.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Schema(description = "다이어리 수신자 등록 요청")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateDiaryReceiverRequest {
+
+    @NotNull(message = "다이어리 ID는 필수입니다.")
+    @Schema(description = "다이어리 ID", example = "1")
+    private Long diaryId;
+
+    @NotEmpty(message = "수신자 ID 목록은 필수입니다.")
+    @Schema(description = "수신자 ID 목록", example = "[1, 2, 3]")
+    private List<Long> receiverIds;
+}

--- a/src/main/java/com/afternote/domain/receiver/dto/CreateUserDailyQuestionReceiverRequest.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/CreateUserDailyQuestionReceiverRequest.java
@@ -1,0 +1,25 @@
+package com.afternote.domain.receiver.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Schema(description = "데일리 질문 수신자 등록 요청")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateUserDailyQuestionReceiverRequest {
+
+    @NotNull(message = "유저 데일리 질문 ID는 필수입니다.")
+    @Schema(description = "유저 데일리 질문(답변) ID", example = "1")
+    private Long userDailyQuestionId;
+
+    @NotEmpty(message = "수신자 ID 목록은 필수입니다.")
+    @Schema(description = "수신자 ID 목록", example = "[1, 2, 3]")
+    private List<Long> receiverIds;
+}

--- a/src/main/java/com/afternote/domain/receiver/dto/ReceivedDailyQuestionListResponse.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/ReceivedDailyQuestionListResponse.java
@@ -1,0 +1,13 @@
+package com.afternote.domain.receiver.dto;
+
+import com.afternote.domain.dailyquestion.dto.DailyQuestionListResponse;
+
+import java.util.List;
+
+public record ReceivedDailyQuestionListResponse(
+        List<DailyQuestionListResponse> dailyQuestions
+) {
+    public static ReceivedDailyQuestionListResponse from(List<DailyQuestionListResponse> dailyQuestions) {
+        return new ReceivedDailyQuestionListResponse(dailyQuestions);
+    }
+}

--- a/src/main/java/com/afternote/domain/receiver/dto/ReceivedDeepThoughtListResponse.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/ReceivedDeepThoughtListResponse.java
@@ -1,0 +1,20 @@
+package com.afternote.domain.receiver.dto;
+
+import com.afternote.domain.deepthought.dto.DeepThoughtResponse;
+import com.afternote.domain.deepthought.dto.DeepThoughtTagCountResponse;
+
+import java.util.List;
+
+public record ReceivedDeepThoughtListResponse(
+        List<String> categories,
+        List<DeepThoughtTagCountResponse> tagCounts,
+        List<DeepThoughtResponse> deepThoughts
+) {
+    public static ReceivedDeepThoughtListResponse from(
+            List<String> categories,
+            List<DeepThoughtTagCountResponse> tagCounts,
+            List<DeepThoughtResponse> deepThoughts
+    ) {
+        return new ReceivedDeepThoughtListResponse(categories, tagCounts, deepThoughts);
+    }
+}

--- a/src/main/java/com/afternote/domain/receiver/dto/ReceivedDiaryListResponse.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/ReceivedDiaryListResponse.java
@@ -1,0 +1,13 @@
+package com.afternote.domain.receiver.dto;
+
+import com.afternote.domain.diary.dto.DiaryResponse;
+
+import java.util.List;
+
+public record ReceivedDiaryListResponse(
+        List<DiaryResponse> diaries
+) {
+    public static ReceivedDiaryListResponse from(List<DiaryResponse> diaries) {
+        return new ReceivedDiaryListResponse(diaries);
+    }
+}

--- a/src/main/java/com/afternote/domain/receiver/model/ReceivedRecordSort.java
+++ b/src/main/java/com/afternote/domain/receiver/model/ReceivedRecordSort.java
@@ -1,0 +1,6 @@
+package com.afternote.domain.receiver.model;
+
+public enum ReceivedRecordSort {
+    LATEST,
+    OLDEST
+}

--- a/src/main/java/com/afternote/domain/receiver/repository/DeepThoughtReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/DeepThoughtReceiverRepository.java
@@ -1,9 +1,13 @@
 package com.afternote.domain.receiver.repository;
 
+import com.afternote.domain.deepthought.dto.DeepThoughtTagCountResponse;
 import com.afternote.domain.receiver.model.DeepThoughtReceiver;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -12,4 +16,72 @@ public interface DeepThoughtReceiverRepository extends JpaRepository<DeepThought
     List<DeepThoughtReceiver> findByDeepThoughtIdAndReceiverIdIn(Long deepThoughtId, List<Long> receiverIds);
 
     void deleteByDeepThoughtId(Long deepThoughtId);
+
+    @Query("""
+        SELECT DISTINCT dtr FROM DeepThoughtReceiver dtr
+        JOIN FETCH dtr.deepThought dt
+        LEFT JOIN FETCH dt.category c
+        LEFT JOIN FETCH dt.tags tags
+        WHERE dtr.receiver.id = :receiverId
+          AND dt.isDraft = false
+          AND (:start IS NULL OR dt.createdAt >= :start)
+          AND (:end IS NULL OR dt.createdAt < :end)
+          AND (:category IS NULL OR c.title = :category)
+          AND (
+                :tag IS NULL
+                OR tags.title = :tag
+                OR dt.title LIKE CONCAT('%', :tag, '%')
+                OR dt.content LIKE CONCAT('%', :tag, '%')
+          )
+    """)
+    List<DeepThoughtReceiver> findReceivedDeepThoughts(
+            @Param("receiverId") Long receiverId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            @Param("category") String category,
+            @Param("tag") String tag
+    );
+
+    @Query("""
+        SELECT DISTINCT c.title FROM DeepThoughtReceiver dtr
+        JOIN dtr.deepThought dt
+        LEFT JOIN dt.category c
+        WHERE dtr.receiver.id = :receiverId
+          AND dt.isDraft = false
+          AND c.title IS NOT NULL
+          AND (:start IS NULL OR dt.createdAt >= :start)
+          AND (:end IS NULL OR dt.createdAt < :end)
+        ORDER BY c.title ASC
+    """)
+    List<String> findReceivedCategoryTitles(
+            @Param("receiverId") Long receiverId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
+
+    @Query("""
+        SELECT NEW com.afternote.domain.deepthought.dto.DeepThoughtTagCountResponse(
+            t.title,
+            COUNT(DISTINCT dt.id)
+        )
+        FROM DeepThoughtReceiver dtr
+        JOIN dtr.deepThought dt
+        JOIN dt.tags t
+        LEFT JOIN dt.category c
+        WHERE dtr.receiver.id = :receiverId
+          AND dt.isDraft = false
+          AND (:start IS NULL OR dt.createdAt >= :start)
+          AND (:end IS NULL OR dt.createdAt < :end)
+          AND (:category IS NULL OR c.title = :category)
+        GROUP BY t.title
+        ORDER BY COUNT(DISTINCT dt.id) DESC, t.title ASC
+    """)
+    List<DeepThoughtTagCountResponse> aggregateReceivedTagCounts(
+            @Param("receiverId") Long receiverId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            @Param("category") String category
+    );
+
+    boolean existsByReceiverId(Long receiverId);
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/DiaryReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/DiaryReceiverRepository.java
@@ -2,8 +2,11 @@ package com.afternote.domain.receiver.repository;
 
 import com.afternote.domain.receiver.model.DiaryReceiver;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -12,4 +15,20 @@ public interface DiaryReceiverRepository extends JpaRepository<DiaryReceiver, Lo
     List<DiaryReceiver> findByDiaryIdAndReceiverIdIn(Long diaryId, List<Long> receiverIds);
 
     void deleteByDiaryId(Long diaryId);
+
+    @Query("""
+        SELECT dr FROM DiaryReceiver dr
+        JOIN FETCH dr.diary d
+        WHERE dr.receiver.id = :receiverId
+          AND d.isDraft = false
+          AND (:start IS NULL OR d.createdAt >= :start)
+          AND (:end IS NULL OR d.createdAt < :end)
+    """)
+    List<DiaryReceiver> findReceivedDiaries(
+            @Param("receiverId") Long receiverId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
+
+    boolean existsByReceiverId(Long receiverId);
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/UserDailyQuestionReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/UserDailyQuestionReceiverRepository.java
@@ -2,8 +2,11 @@ package com.afternote.domain.receiver.repository;
 
 import com.afternote.domain.receiver.model.UserDailyQuestionReceiver;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -12,4 +15,22 @@ public interface UserDailyQuestionReceiverRepository extends JpaRepository<UserD
     List<UserDailyQuestionReceiver> findByUserDailyQuestionIdAndReceiverIdIn(Long userDailyQuestionId, List<Long> receiverIds);
 
     void deleteByUserDailyQuestionId(Long userDailyQuestionId);
+
+    @Query("""
+        SELECT udqr FROM UserDailyQuestionReceiver udqr
+        JOIN FETCH udqr.userDailyQuestion udq
+        JOIN FETCH udq.dailyQuestion dq
+        WHERE udqr.receiver.id = :receiverId
+          AND udq.isDraft = false
+          AND udq.isAnswered = true
+          AND (:start IS NULL OR udq.createdAt >= :start)
+          AND (:end IS NULL OR udq.createdAt < :end)
+    """)
+    List<UserDailyQuestionReceiver> findReceivedDailyQuestions(
+            @Param("receiverId") Long receiverId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
+
+    boolean existsByReceiverId(Long receiverId);
 }

--- a/src/main/java/com/afternote/domain/receiver/service/ReceivedService.java
+++ b/src/main/java/com/afternote/domain/receiver/service/ReceivedService.java
@@ -2,25 +2,20 @@ package com.afternote.domain.receiver.service;
 
 import com.afternote.domain.afternote.model.Afternote;
 import com.afternote.domain.afternote.model.AfternoteReceiver;
+import com.afternote.domain.dailyquestion.dto.DailyQuestionListResponse;
 import com.afternote.domain.dailyquestion.model.UserDailyQuestion;
 import com.afternote.domain.dailyquestion.repository.UserDailyQuestionRepository;
+import com.afternote.domain.deepthought.dto.DeepThoughtResponse;
+import com.afternote.domain.deepthought.dto.DeepThoughtTagCountResponse;
 import com.afternote.domain.deepthought.model.DeepThought;
 import com.afternote.domain.deepthought.repository.DeepThoughtRepository;
+import com.afternote.domain.diary.dto.DiaryResponse;
 import com.afternote.domain.diary.model.Diary;
 import com.afternote.domain.diary.repository.DiaryRepository;
 import com.afternote.domain.image.service.S3Service;
 import com.afternote.domain.receiver.dto.*;
-import com.afternote.domain.receiver.model.DeepThoughtReceiver;
-import com.afternote.domain.receiver.model.DiaryReceiver;
-import com.afternote.domain.receiver.model.Receiver;
-import com.afternote.domain.receiver.model.TimeLetterReceiver;
-import com.afternote.domain.receiver.model.UserDailyQuestionReceiver;
-import com.afternote.domain.receiver.repository.AfternoteReceiverRepository;
-import com.afternote.domain.receiver.repository.DeepThoughtReceiverRepository;
-import com.afternote.domain.receiver.repository.DiaryReceiverRepository;
-import com.afternote.domain.receiver.repository.ReceiverRepository;
-import com.afternote.domain.receiver.repository.TimeLetterReceiverRepository;
-import com.afternote.domain.receiver.repository.UserDailyQuestionReceiverRepository;
+import com.afternote.domain.receiver.model.*;
+import com.afternote.domain.receiver.repository.*;
 import com.afternote.domain.timeletter.model.TimeLetter;
 import com.afternote.domain.timeletter.repository.TimeLetterRepository;
 import com.afternote.domain.user.model.User;
@@ -31,12 +26,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -57,6 +50,9 @@ public class ReceivedService {
     private final UserDailyQuestionRepository userDailyQuestionRepository;
     private final UserRepository userRepository;
     private final S3Service s3Service;
+
+    private static final DateTimeFormatter KOREAN_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy.MM.dd E", Locale.KOREAN);
 
     /**
      * 수신자가 받은 타임레터 목록 조회
@@ -403,5 +399,220 @@ public class ReceivedService {
         if (!sender.isDeliveryConditionMet()) {
             throw new CustomException(ErrorCode.DELIVERY_CONDITION_NOT_MET);
         }
+    }
+    /**
+     * 수신자가 받은 일기 목록 조회
+     * - 수신자 ID 기준으로 DiaryReceiver 목록을 조회한다.
+     * - 임시저장이 아닌 정식 등록 일기만 반환한다.
+     * - startDate/endDate가 있으면 원본 일기 작성일 기준으로 기간 필터링한다.
+     * - sort 값에 따라 최신순 또는 오래된순으로 정렬한다.
+     */
+    public ReceivedDiaryListResponse getReceivedDiaries(
+            Long receiverId,
+            ReceivedRecordSort sort,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        // 수신자 존재 여부 및 배달 조건 검증
+        validateReceiver(receiverId);
+
+        // 날짜 조건을 LocalDateTime 범위로 변환
+        LocalDateTime start = toStartDateTime(startDate);
+        LocalDateTime end = toEndDateTime(endDate);
+
+        List<DiaryResponse> diaries = diaryReceiverRepository
+                .findReceivedDiaries(receiverId, start, end)
+                .stream()
+                // 연결 엔티티에서 실제 Diary 엔티티만 꺼낸다.
+                .map(DiaryReceiver::getDiary)
+                // 요청한 정렬 기준에 따라 createdAt 기준 정렬
+                .sorted(diaryComparator(sort))
+                // 기존 Diary 응답 DTO로 변환
+                .map(DiaryResponse::from)
+                .toList();
+
+        return ReceivedDiaryListResponse.from(diaries);
+    }
+
+    /**
+     * 수신자가 받은 깊은 생각 목록 조회
+     * - 수신자 ID 기준으로 DeepThoughtReceiver 목록을 조회한다.
+     * - 임시저장이 아닌 정식 등록 깊은 생각만 반환한다.
+     * - 기간, 카테고리, 태그 조건으로 필터링할 수 있다.
+     * - 태그 검색어는 태그명뿐 아니라 제목/내용 검색에도 사용된다.
+     * - 응답에는 깊은 생각 목록과 함께 카테고리 목록, 태그별 글 개수를 포함한다.
+     */
+    public ReceivedDeepThoughtListResponse getReceivedDeepThoughts(
+            Long receiverId,
+            String category,
+            String tag,
+            ReceivedRecordSort sort,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        // 수신자 존재 여부 및 배달 조건 검증
+        validateReceiver(receiverId);
+
+        // 날짜 조건을 LocalDateTime 범위로 변환
+        LocalDateTime start = toStartDateTime(startDate);
+        LocalDateTime end = toEndDateTime(endDate);
+
+        // 검색 조건 공백 제거 및 null 처리
+        String normalizedCategory = normalizeSearchParam(category);
+        String normalizedTag = normalizeTag(tag);
+
+        List<DeepThought> thoughts = deepThoughtReceiverRepository
+                .findReceivedDeepThoughts(receiverId, start, end, normalizedCategory, normalizedTag)
+                .stream()
+                // 연결 엔티티에서 실제 DeepThought 엔티티만 꺼낸다.
+                .map(DeepThoughtReceiver::getDeepThought)
+                // 태그 JOIN으로 인해 중복될 수 있는 깊은 생각을 제거
+                .distinct()
+                // 요청한 정렬 기준에 따라 createdAt 기준 정렬
+                .sorted(deepThoughtComparator(sort))
+                .toList();
+
+        // 필터 UI에 사용할 카테고리 목록 조회
+        List<String> categories = deepThoughtReceiverRepository
+                .findReceivedCategoryTitles(receiverId, start, end);
+
+        // 태그별 글 개수 조회
+        // tag 검색어는 목록 필터에만 적용하고, 태그 개수 집계에는 적용하지 않는다.
+        List<DeepThoughtTagCountResponse> tagCounts = deepThoughtReceiverRepository
+                .aggregateReceivedTagCounts(receiverId, start, end, normalizedCategory);
+
+        // 기존 DeepThought 응답 DTO로 변환
+        List<DeepThoughtResponse> deepThoughts = thoughts.stream()
+                .map(DeepThoughtResponse::from)
+                .toList();
+
+        return ReceivedDeepThoughtListResponse.from(categories, tagCounts, deepThoughts);
+    }
+
+    /**
+     * 수신자가 받은 데일리 질문 답변 목록 조회
+     * - 수신자 ID 기준으로 UserDailyQuestionReceiver 목록을 조회한다.
+     * - 임시저장이 아니고 답변 완료된 데일리 질문만 반환한다.
+     * - startDate/endDate가 있으면 답변 작성일 기준으로 기간 필터링한다.
+     * - sort 값에 따라 최신순 또는 오래된순으로 정렬한다.
+     */
+    public ReceivedDailyQuestionListResponse getReceivedDailyQuestions(
+            Long receiverId,
+            ReceivedRecordSort sort,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        // 수신자 존재 여부 및 배달 조건 검증
+        validateReceiver(receiverId);
+
+        // 날짜 조건을 LocalDateTime 범위로 변환
+        LocalDateTime start = toStartDateTime(startDate);
+        LocalDateTime end = toEndDateTime(endDate);
+
+        List<DailyQuestionListResponse> dailyQuestions = userDailyQuestionReceiverRepository
+                .findReceivedDailyQuestions(receiverId, start, end)
+                .stream()
+                // 연결 엔티티에서 실제 UserDailyQuestion 엔티티만 꺼낸다.
+                .map(UserDailyQuestionReceiver::getUserDailyQuestion)
+                // 요청한 정렬 기준에 따라 createdAt 기준 정렬
+                .sorted(userDailyQuestionComparator(sort))
+                // 데일리 질문 목록 응답 DTO로 변환
+                .map(this::toDailyQuestionListResponse)
+                .toList();
+
+        return ReceivedDailyQuestionListResponse.from(dailyQuestions);
+    }
+
+    /**
+     * 조회 시작일을 LocalDateTime으로 변환
+     * - startDate가 있으면 해당 날짜의 00:00:00으로 변환한다.
+     * - 없으면 Repository 조건에서 필터링하지 않도록 null을 반환한다.
+     */
+    private LocalDateTime toStartDateTime(LocalDate startDate) {
+        return startDate != null ? startDate.atStartOfDay() : null;
+    }
+
+    /**
+     * 조회 종료일을 LocalDateTime으로 변환
+     * - endDate가 있으면 다음 날 00:00:00으로 변환한다.
+     * - Repository에서는 '< end' 조건을 사용하므로 종료일 당일까지 포함된다.
+     * - 없으면 Repository 조건에서 필터링하지 않도록 null을 반환한다.
+     */
+    private LocalDateTime toEndDateTime(LocalDate endDate) {
+        return endDate != null ? endDate.plusDays(1).atStartOfDay() : null;
+    }
+
+    /**
+     * 검색 파라미터 정규화
+     * - null 또는 공백 문자열이면 검색 조건을 적용하지 않도록 null을 반환한다.
+     * - 값이 있으면 앞뒤 공백을 제거한다.
+     */
+    private String normalizeSearchParam(String value) {
+        if (value == null || value.trim().isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    /**
+     * 태그 검색어 정규화
+     * - null 또는 공백 문자열이면 태그 검색 조건을 적용하지 않도록 null을 반환한다.
+     * - 프론트에서 '#성장'처럼 전달해도 DB 값과 비교할 수 있도록 '#'을 제거한다.
+     */
+    private String normalizeTag(String tag) {
+        if (tag == null || tag.trim().isBlank()) {
+            return null;
+        }
+
+        String normalized = tag.trim();
+        return normalized.startsWith("#") ? normalized.substring(1) : normalized;
+    }
+
+    /**
+     * 일기 정렬 조건 생성
+     * - LATEST이면 createdAt 기준 최신순
+     * - OLDEST이면 createdAt 기준 오래된순
+     */
+    private Comparator<Diary> diaryComparator(ReceivedRecordSort sort) {
+        Comparator<Diary> comparator = Comparator.comparing(Diary::getCreatedAt);
+        return sort == ReceivedRecordSort.OLDEST ? comparator : comparator.reversed();
+    }
+
+    /**
+     * 깊은 생각 정렬 조건 생성
+     * - LATEST이면 createdAt 기준 최신순
+     * - OLDEST이면 createdAt 기준 오래된순
+     */
+    private Comparator<DeepThought> deepThoughtComparator(ReceivedRecordSort sort) {
+        Comparator<DeepThought> comparator = Comparator.comparing(DeepThought::getCreatedAt);
+        return sort == ReceivedRecordSort.OLDEST ? comparator : comparator.reversed();
+    }
+
+    /**
+     * 데일리 질문 답변 정렬 조건 생성
+     * - LATEST이면 createdAt 기준 최신순
+     * - OLDEST이면 createdAt 기준 오래된순
+     */
+    private Comparator<UserDailyQuestion> userDailyQuestionComparator(ReceivedRecordSort sort) {
+        Comparator<UserDailyQuestion> comparator = Comparator.comparing(UserDailyQuestion::getCreatedAt);
+        return sort == ReceivedRecordSort.OLDEST ? comparator : comparator.reversed();
+    }
+
+    /**
+     * UserDailyQuestion 엔티티를 목록 응답 DTO로 변환
+     * - title에는 원본 데일리 질문 내용을 담는다.
+     * - content에는 사용자가 작성한 답변 내용을 담는다.
+     * - createdAt은 기존 데일리 질문 목록과 동일한 yyyy.MM.dd E 형식으로 변환한다.
+     */
+    private DailyQuestionListResponse toDailyQuestionListResponse(UserDailyQuestion userDailyQuestion) {
+        return DailyQuestionListResponse.builder()
+                .userDailyQuestionId(userDailyQuestion.getId())
+                .title(userDailyQuestion.getDailyQuestion().getContent())
+                .content(userDailyQuestion.getContent())
+                .createdAt(userDailyQuestion.getCreatedAt() != null
+                        ? userDailyQuestion.getCreatedAt().format(KOREAN_DATE_FORMATTER)
+                        : null)
+                .imageUrl(userDailyQuestion.getImageUrl())
+                .build();
     }
 }

--- a/src/main/java/com/afternote/domain/receiver/service/ReceiverAuthService.java
+++ b/src/main/java/com/afternote/domain/receiver/service/ReceiverAuthService.java
@@ -6,6 +6,10 @@ import com.afternote.domain.receiver.dto.*;
 import com.afternote.domain.receiver.model.DeliveryVerification;
 import com.afternote.domain.receiver.model.ReceivedRecordStatus;
 import com.afternote.domain.receiver.model.Receiver;
+import com.afternote.domain.receiver.model.ReceivedRecordSort;
+import com.afternote.domain.receiver.repository.DiaryReceiverRepository;
+import com.afternote.domain.receiver.repository.DeepThoughtReceiverRepository;
+import com.afternote.domain.receiver.repository.UserDailyQuestionReceiverRepository;
 import com.afternote.domain.receiver.repository.AfternoteReceiverRepository;
 import com.afternote.domain.receiver.repository.DeliveryVerificationRepository;
 import com.afternote.domain.receiver.repository.ReceiverRepository;
@@ -19,6 +23,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +52,9 @@ public class ReceiverAuthService {
     private final DeliveryVerificationRepository deliveryVerificationRepository;
     private final TimeLetterReceiverRepository timeLetterReceiverRepository;
     private final AfternoteReceiverRepository afternoteReceiverRepository;
+    private final DiaryReceiverRepository diaryReceiverRepository;
+    private final DeepThoughtReceiverRepository deepThoughtReceiverRepository;
+    private final UserDailyQuestionReceiverRepository userDailyQuestionReceiverRepository;
 
     public ReceiverAuthVerifyResponse verifyAuthCode(String authCode) {
         Receiver receiver = findReceiverByAuthCode(authCode);
@@ -285,11 +293,69 @@ public class ReceiverAuthService {
     private ReceivedRecordStatus determineRecordStatus(Long receiverId) {
         boolean hasTimeLetter = timeLetterReceiverRepository.existsByReceiverId(receiverId);
         boolean hasAfternote = afternoteReceiverRepository.existsByReceiverId(receiverId);
+        boolean hasDiary = diaryReceiverRepository.existsByReceiverId(receiverId);
+        boolean hasDeepThought = deepThoughtReceiverRepository.existsByReceiverId(receiverId);
+        boolean hasDailyQuestion = userDailyQuestionReceiverRepository.existsByReceiverId(receiverId);
 
-        if (hasTimeLetter || hasAfternote) {
+        if (hasTimeLetter || hasAfternote || hasDiary || hasDeepThought || hasDailyQuestion) {
             return ReceivedRecordStatus.STORED;
         }
 
         return ReceivedRecordStatus.EMPTY;
+    }
+
+    public ReceivedDiaryListResponse getReceivedDiaries(
+            String authCode,
+            ReceivedRecordSort sort,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        Receiver receiver = findReceiverByAuthCode(authCode);
+        validateDeliveryCondition(receiver);
+
+        return receivedService.getReceivedDiaries(
+                receiver.getId(),
+                sort,
+                startDate,
+                endDate
+        );
+    }
+
+    public ReceivedDeepThoughtListResponse getReceivedDeepThoughts(
+            String authCode,
+            String category,
+            String tag,
+            ReceivedRecordSort sort,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        Receiver receiver = findReceiverByAuthCode(authCode);
+        validateDeliveryCondition(receiver);
+
+        return receivedService.getReceivedDeepThoughts(
+                receiver.getId(),
+                category,
+                tag,
+                sort,
+                startDate,
+                endDate
+        );
+    }
+
+    public ReceivedDailyQuestionListResponse getReceivedDailyQuestions(
+            String authCode,
+            ReceivedRecordSort sort,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        Receiver receiver = findReceiverByAuthCode(authCode);
+        validateDeliveryCondition(receiver);
+
+        return receivedService.getReceivedDailyQuestions(
+                receiver.getId(),
+                sort,
+                startDate,
+                endDate
+        );
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
close #60

## ✨ 작업 내용
-수신자 마인드 레코드 조회 api를 깊은 생각/일기/데일리 질문 조회 api로 변경했습니다.

## 🛠️ 테스트 계획 및 결과
- [x] 로컬 API 테스트(Postman/Swagger) 완료
- [ ] API 테스트(Postman/Swagger) 완료

## 📚 체크리스트
- [x] 브랜치 전략에 맞는 브랜치인가요? (`[이름]/[타입]/[기능]`)
- [x] 커밋 메시지 컨벤션을 준수했나요? (`[타입] 제목`)
- [x] 불필요한 주석이나 print문은 제거했나요?

## 스크린샷 (선택)


## 💬 리뷰어에게 (선택)