### PR TITLE
feat: 인증 목록 API 응답에 expiresIn 추가

### DIFF
--- a/src/main/java/com/afternote/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/afternote/domain/admin/controller/AdminController.java
@@ -4,6 +4,7 @@ import com.afternote.domain.admin.dto.AdminVerificationActionRequest;
 import com.afternote.domain.admin.dto.AdminVerificationResponse;
 import com.afternote.domain.admin.service.AdminService;
 import com.afternote.global.common.ApiResponse;
+import com.afternote.global.common.IncludeAccessTokenExpiresIn;
 import com.afternote.global.resolver.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -21,6 +22,7 @@ public class AdminController {
 
     private final AdminService adminService;
 
+    @IncludeAccessTokenExpiresIn
     @Operation(
             summary = "대기 중인 인증 요청 목록 조회",
             description = """

--- a/src/main/java/com/afternote/domain/afternote/controller/AfternoteController.java
+++ b/src/main/java/com/afternote/domain/afternote/controller/AfternoteController.java
@@ -7,6 +7,7 @@ import com.afternote.domain.afternote.dto.AfternotedetailResponse;
 import com.afternote.domain.afternote.model.AfternoteCategoryType;
 import com.afternote.domain.afternote.service.AfternoteService;
 import com.afternote.global.common.ApiResponse;
+import com.afternote.global.common.IncludeAccessTokenExpiresIn;
 import com.afternote.global.resolver.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -23,6 +24,7 @@ public class AfternoteController {
 
     private final AfternoteService afternoteService;
 
+    @IncludeAccessTokenExpiresIn
     @Operation(
             summary = "애프터노트 목록 조회 API",
             description = "애프터노트 목록을 가져옵니다. param으로 category와 page, size를 보내주시면 됩니다."

--- a/src/main/java/com/afternote/domain/dailyquestion/controller/DailyQuestionController.java
+++ b/src/main/java/com/afternote/domain/dailyquestion/controller/DailyQuestionController.java
@@ -3,6 +3,7 @@ package com.afternote.domain.dailyquestion.controller;
 import com.afternote.domain.dailyquestion.dto.*;
 import com.afternote.domain.dailyquestion.service.DailyQuestionService;
 import com.afternote.global.common.ApiResponse;
+import com.afternote.global.common.IncludeAccessTokenExpiresIn;
 import com.afternote.global.resolver.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -50,6 +51,7 @@ public class DailyQuestionController {
         return ApiResponse.success(dailyQuestionService.updateAnswer(userId, userDailyQuestionId, request));
     }
 
+    @IncludeAccessTokenExpiresIn
     @Operation(summary = "데일리 질문 목록 조회", description = "특정 날짜 혹은 전체 답변 목록을 최신순으로 조회합니다. draftOnly=true이면 임시저장 답변만, 그렇지 않으면 제출 완료(비임시) 답변만 반환합니다.")
     @GetMapping
     public ApiResponse<List<DailyQuestionListResponse>> getDailyQuestions(

--- a/src/main/java/com/afternote/domain/deepthought/controller/DeepThoughtController.java
+++ b/src/main/java/com/afternote/domain/deepthought/controller/DeepThoughtController.java
@@ -11,6 +11,7 @@ import com.afternote.domain.deepthought.dto.DeepThoughtUpdateRequest;
 import com.afternote.domain.deepthought.service.DeepThoughtCategoryService;
 import com.afternote.domain.deepthought.service.DeepThoughtService;
 import com.afternote.global.common.ApiResponse;
+import com.afternote.global.common.IncludeAccessTokenExpiresIn;
 import com.afternote.global.resolver.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -50,6 +51,7 @@ public class DeepThoughtController {
         return ApiResponse.success(deepThoughtService.updateDeepThought(userId, deepThoughtId, request));
     }
 
+    @IncludeAccessTokenExpiresIn
     @Operation(summary = "깊은 생각 조회", description = "날짜/태그/카테고리 조건으로 깊은 생각을 조회합니다. draftOnly=true이면 임시저장만 반환합니다. "
             + "응답의 tagCounts에는 동일한 날짜·카테고리·draftOnly 범위에서 태그별 글 개수가 포함되며, 목록 필터용 tag 검색어는 집계에 반영하지 않습니다.")
     @GetMapping
@@ -82,6 +84,7 @@ public class DeepThoughtController {
         return ApiResponse.success(null);
     }
 
+    @IncludeAccessTokenExpiresIn
     @Operation(summary = "카테고리 조회", description = "유저의 깊은 생각 카테고리 목록을 조회합니다.")
     @GetMapping("/categories")
     public ApiResponse<DeepThoughtCategoryListResponse> getCategories(

--- a/src/main/java/com/afternote/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/afternote/domain/diary/controller/DiaryController.java
@@ -6,6 +6,7 @@ import com.afternote.domain.diary.dto.DiaryResponse;
 import com.afternote.domain.diary.dto.DiaryUpdateRequest;
 import com.afternote.domain.diary.service.DiaryService;
 import com.afternote.global.common.ApiResponse;
+import com.afternote.global.common.IncludeAccessTokenExpiresIn;
 import com.afternote.global.resolver.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -40,6 +41,7 @@ public class DiaryController {
         return ApiResponse.success(diaryService.createDiary(userId, request));
     }
 
+    @IncludeAccessTokenExpiresIn
     @Operation(summary = "Diary 월 단위 조회", description = "지정한 yyyy-MM 한 달의 다이어리 전체를 최신순으로 조회합니다. "
             + "캘린더형 화면은 응답을 날짜별로 그룹핑하여 셀에 표시하고, 카드형 화면은 그대로 그리드에 렌더하면 됩니다. "
             + "draftOnly=true이면 해당 달의 임시저장만 반환합니다. "

--- a/src/main/java/com/afternote/domain/timeletter/controller/TimeLetterController.java
+++ b/src/main/java/com/afternote/domain/timeletter/controller/TimeLetterController.java
@@ -7,6 +7,7 @@ import com.afternote.domain.timeletter.dto.response.TimeLetterListResponse;
 import com.afternote.domain.timeletter.dto.response.TimeLetterResponse;
 import com.afternote.domain.timeletter.service.TimeLetterService;
 import com.afternote.global.common.ApiResponse;
+import com.afternote.global.common.IncludeAccessTokenExpiresIn;
 import com.afternote.global.resolver.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -23,6 +24,7 @@ public class TimeLetterController {
 
     private final TimeLetterService timeLetterService;
 
+    @IncludeAccessTokenExpiresIn
     @Operation(summary = "타임레터 전체 조회", description = "정식 등록된(SCHEDULED) 타임레터 전체를 조회합니다.")
     @GetMapping
     public ApiResponse<TimeLetterListResponse> getTimeLetters(
@@ -46,6 +48,7 @@ public class TimeLetterController {
         return ApiResponse.success(timeLetterService.createTimeLetter(userId, request));
     }
 
+    @IncludeAccessTokenExpiresIn
     @Operation(summary = "임시저장 전체 조회", description = "임시저장된(DRAFT) 타임레터 전체를 조회합니다.")
     @GetMapping("/temporary")
     public ApiResponse<TimeLetterListResponse> getTemporaryTimeLetters(

--- a/src/main/java/com/afternote/domain/user/controller/UserController.java
+++ b/src/main/java/com/afternote/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.afternote.domain.user.controller;
 import com.afternote.domain.user.dto.*;
 import com.afternote.domain.user.service.UserService;
 import com.afternote.global.common.ApiResponse;
+import com.afternote.global.common.IncludeAccessTokenExpiresIn;
 import com.afternote.global.resolver.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -124,6 +125,7 @@ public class UserController {
         );
     }
 
+    @IncludeAccessTokenExpiresIn
     @Operation(
             summary = "수신인 목록 조회 API",
             description = "로그인한 사용자가 등록한 수신인 목록을 조회합니다."

--- a/src/main/java/com/afternote/global/common/AccessTokenExpiresInAdvice.java
+++ b/src/main/java/com/afternote/global/common/AccessTokenExpiresInAdvice.java
@@ -1,0 +1,39 @@
+package com.afternote.global.common;
+
+import com.afternote.global.jwt.JwtAuthenticationFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@ControllerAdvice
+public class AccessTokenExpiresInAdvice implements ResponseBodyAdvice<ApiResponse<?>> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return returnType.hasMethodAnnotation(IncludeAccessTokenExpiresIn.class);
+    }
+
+    @Override
+    public ApiResponse<?> beforeBodyWrite(
+            ApiResponse<?> body,
+            MethodParameter returnType,
+            MediaType selectedContentType,
+            Class<? extends HttpMessageConverter<?>> selectedConverterType,
+            ServerHttpRequest request,
+            ServerHttpResponse response
+    ) {
+        if (body == null || !(request instanceof ServletServerHttpRequest servletRequest)) {
+            return body;
+        }
+
+        HttpServletRequest httpRequest = servletRequest.getServletRequest();
+        Long expiresIn = (Long) httpRequest.getAttribute(JwtAuthenticationFilter.ACCESS_TOKEN_EXPIRES_IN_ATTRIBUTE);
+        return body.withExpiresIn(expiresIn);
+    }
+}

--- a/src/main/java/com/afternote/global/common/ApiResponse.java
+++ b/src/main/java/com/afternote/global/common/ApiResponse.java
@@ -1,6 +1,7 @@
 package com.afternote.global.common;
 
 import com.afternote.global.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -15,9 +16,16 @@ public class ApiResponse<T> {
     private String message;
     private T data;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Long expiresIn;
+
     // 성공 시 (200 OK)
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(HttpStatus.OK.value(), 200, "성공", data);
+        return new ApiResponse<>(HttpStatus.OK.value(), 200, "성공", data, null);
+    }
+
+    public ApiResponse<T> withExpiresIn(Long expiresIn) {
+        return new ApiResponse<>(status, code, message, data, expiresIn);
     }
 
     // ★ 핵심: ErrorCode를 받아서 자동으로 채워주는 메서드
@@ -26,12 +34,13 @@ public class ApiResponse<T> {
                 errorCode.getHttpStatus().value(),
                 errorCode.getCode(),
                 errorCode.getMessage(),
+                null,
                 null
         );
     }
 
     // 예외적인 에러 메시지를 직접 넣어야 할 때
     public static ApiResponse<Void> error(int status, int code, String message) {
-        return new ApiResponse<>(status, code, message, null);
+        return new ApiResponse<>(status, code, message, null, null);
     }
 }

--- a/src/main/java/com/afternote/global/common/IncludeAccessTokenExpiresIn.java
+++ b/src/main/java/com/afternote/global/common/IncludeAccessTokenExpiresIn.java
@@ -1,0 +1,14 @@
+package com.afternote.global.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 응답 body에 Access Token 남은 만료 시간(expiresIn, 초)을 포함합니다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IncludeAccessTokenExpiresIn {
+}

--- a/src/main/java/com/afternote/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/afternote/global/jwt/JwtAuthenticationFilter.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    public static final String ACCESS_TOKEN_EXPIRES_IN_ATTRIBUTE = "accessTokenExpiresIn";
+
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
@@ -38,6 +40,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             // 4. Request Attribute에 userId 저장 (컨트롤러에서 @AuthUser로 접근 가능)
             request.setAttribute(UserIdArgumentResolver.USER_ID_ATTRIBUTE, userId);
+            request.setAttribute(
+                    ACCESS_TOKEN_EXPIRES_IN_ATTRIBUTE,
+                    jwtTokenProvider.getRemainingExpirationSeconds(token)
+            );
 
             // 5. 유저 정보를 임시로 만들어서 SecurityContext에 넣어주기 (로그인 인정)
             // (권한은 일단 USER로 통일. 실제로는 DB에서 조회해서 넣을 수도 있음)

--- a/src/main/java/com/afternote/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/afternote/global/jwt/JwtTokenProvider.java
@@ -69,4 +69,16 @@ public class JwtTokenProvider {
             return false;
         }
     }
+
+    /**
+     * @return Access Token 만료까지 남은 시간(초). 이미 만료된 경우 0.
+     */
+    public long getRemainingExpirationSeconds(String token) {
+        Date expiration = Jwts.parser().verifyWith(key).build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration();
+        long remainingMs = expiration.getTime() - System.currentTimeMillis();
+        return Math.max(0, remainingMs / 1000);
+    }
 }

--- a/src/test/java/com/afternote/global/common/AccessTokenExpiresInAdviceTest.java
+++ b/src/test/java/com/afternote/global/common/AccessTokenExpiresInAdviceTest.java
@@ -1,0 +1,51 @@
+package com.afternote.global.common;
+
+import com.afternote.global.jwt.JwtAuthenticationFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AccessTokenExpiresInAdviceTest {
+
+    private final AccessTokenExpiresInAdvice advice = new AccessTokenExpiresInAdvice();
+
+    @Test
+    @DisplayName("@IncludeAccessTokenExpiresIn가 붙은 ApiResponse에 expiresIn을 주입한다")
+    void beforeBodyWrite_addsExpiresIn() throws Exception {
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        servletRequest.setAttribute(JwtAuthenticationFilter.ACCESS_TOKEN_EXPIRES_IN_ATTRIBUTE, 1800L);
+        ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
+
+        ApiResponse<String> body = ApiResponse.success("ok");
+        MethodParameter returnType = new MethodParameter(
+                SampleController.class.getMethod("sample", String.class),
+                -1
+        );
+
+        ApiResponse<?> result = advice.beforeBodyWrite(
+                body,
+                returnType,
+                MediaType.APPLICATION_JSON,
+                StringHttpMessageConverter.class,
+                request,
+                null
+        );
+
+        assertThat(result.getExpiresIn()).isEqualTo(1800L);
+        assertThat(result.getData()).isEqualTo("ok");
+    }
+
+    static class SampleController {
+        @IncludeAccessTokenExpiresIn
+        public ApiResponse<String> sample(String ignored) {
+            return ApiResponse.success("ok");
+        }
+    }
+}

--- a/src/test/java/com/afternote/global/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/afternote/global/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,31 @@
+package com.afternote.global.jwt;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = new JwtTokenProvider(
+                "01234567890123456789012345678901",
+                3_600_000L,
+                7 * 24 * 60 * 60 * 1000L
+        );
+    }
+
+    @Test
+    @DisplayName("Access Token 남은 만료 시간(초)을 반환한다")
+    void getRemainingExpirationSeconds() {
+        String accessToken = jwtTokenProvider.generateAccessToken(1L);
+
+        long expiresIn = jwtTokenProvider.getRemainingExpirationSeconds(accessToken);
+
+        assertThat(expiresIn).isBetween(3590L, 3600L);
+    }
+}


### PR DESCRIPTION
Expose remaining access token lifetime in seconds so clients can refresh before expiry on list endpoints.

## 📌 관련 이슈
close #

## ✨ 작업 내용
-

## 🛠️ 테스트 계획 및 결과
- [ ] 로컬 API 테스트(Postman/Swagger) 완료
- [ ] API 테스트(Postman/Swagger) 완료

## 📚 체크리스트
- [ ] 브랜치 전략에 맞는 브랜치인가요? (`[이름]/[타입]/[기능]`)
- [ ] 커밋 메시지 컨벤션을 준수했나요? (`[타입] 제목`)
- [ ] 불필요한 주석이나 print문은 제거했나요?

## 스크린샷 (선택)


## 💬 리뷰어에게 (선택)