### PR TITLE
feat: 로컬 계정 이메일·비밀번호 찾기 API 추가

### DIFF
--- a/src/main/java/com/afternote/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/afternote/domain/auth/controller/AuthController.java
@@ -85,6 +85,42 @@ public class AuthController {
     }
 
     @Operation(
+            summary = "아이디/비밀번호 찾기 인증번호 발송 API",
+            description = "로컬(이메일) 계정의 아이디/비밀번호 찾기용 인증번호를 발송합니다."
+    )
+    @PostMapping("/find/send/code")
+    public ApiResponse<Object> findSendCode(
+            @Valid @RequestBody FindSendCodeRequest findSendCodeRequest
+    ) {
+        authService.findSendCode(findSendCodeRequest);
+        return ApiResponse.success(null);
+    }
+
+    @Operation(
+            summary = "아이디(이메일) 찾기 API",
+            description = "이메일과 인증번호를 검증한 뒤 아이디(이메일)를 반환합니다."
+    )
+    @PostMapping("/email/find")
+    public ApiResponse<EmailFindResponse> findEmail(
+            @Valid @RequestBody EmailFindRequest emailFindRequest
+    ) {
+        EmailFindResponse response = authService.findEmail(emailFindRequest);
+        return ApiResponse.success(response);
+    }
+
+    @Operation(
+            summary = "비밀번호 찾기 API",
+            description = "이메일·인증번호·새 비밀번호를 검증한 뒤 비밀번호를 재설정합니다."
+    )
+    @PostMapping("/password/find")
+    public ApiResponse<Object> findPassword(
+            @Valid @RequestBody PasswordFindRequest passwordFindRequest
+    ) {
+        authService.findPassword(passwordFindRequest);
+        return ApiResponse.success(null);
+    }
+
+    @Operation(
         summary = "통합 소셜 로그인 API 🎯", 
         description = """
             모든 소셜 로그인 제공자를 통합한 API입니다.

--- a/src/main/java/com/afternote/domain/auth/dto/EmailFindRequest.java
+++ b/src/main/java/com/afternote/domain/auth/dto/EmailFindRequest.java
@@ -1,0 +1,23 @@
+package com.afternote.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailFindRequest {
+
+    @Schema(description = "가입 시 사용한 이메일", example = "user@example.com")
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @Schema(description = "이메일 인증번호 (6자리)", example = "123456")
+    @NotBlank(message = "인증번호를 입력해주세요.")
+    @Pattern(regexp = "^[0-9]{6}$", message = "인증번호는 6자리 숫자여야 합니다.")
+    private String certificateCode;
+}

--- a/src/main/java/com/afternote/domain/auth/dto/EmailFindResponse.java
+++ b/src/main/java/com/afternote/domain/auth/dto/EmailFindResponse.java
@@ -1,0 +1,20 @@
+package com.afternote.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmailFindResponse {
+
+    @Schema(description = "회원 이름", example = "박지현")
+    private String name;
+
+    @Schema(description = "아이디(이메일)", example = "parkchan01@example.com")
+    private String email;
+
+    public static EmailFindResponse from(String name, String email) {
+        return new EmailFindResponse(name, email);
+    }
+}

--- a/src/main/java/com/afternote/domain/auth/dto/FindSendCodeRequest.java
+++ b/src/main/java/com/afternote/domain/auth/dto/FindSendCodeRequest.java
@@ -1,0 +1,17 @@
+package com.afternote.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FindSendCodeRequest {
+
+    @Schema(description = "가입 시 사용한 이메일", example = "user@example.com")
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/src/main/java/com/afternote/domain/auth/dto/PasswordChangeRequest.java
+++ b/src/main/java/com/afternote/domain/auth/dto/PasswordChangeRequest.java
@@ -17,8 +17,7 @@ public class PasswordChangeRequest {
 
 
     @Schema(description = "새 비밀번호", example = "password123!")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
-            message = "비밀번호는 8~20자의 영문 대소문자, 숫자, 특수문자를 포함해야 합니다.")
+    @Pattern(regexp = PasswordValidation.REGEX, message = PasswordValidation.MESSAGE)
     @NotBlank(message = "새 비밀번호를 입력해주세요.")
     private String newPassword;
 

--- a/src/main/java/com/afternote/domain/auth/dto/PasswordFindRequest.java
+++ b/src/main/java/com/afternote/domain/auth/dto/PasswordFindRequest.java
@@ -1,0 +1,32 @@
+package com.afternote.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PasswordFindRequest {
+
+    @Schema(description = "가입 시 사용한 이메일", example = "user@example.com")
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @Schema(description = "이메일 인증번호 (6자리)", example = "123456")
+    @NotBlank(message = "인증번호를 입력해주세요.")
+    @Pattern(regexp = "^[0-9]{6}$", message = "인증번호는 6자리 숫자여야 합니다.")
+    private String certificateCode;
+
+    @Schema(description = "새 비밀번호", example = "Password1!")
+    @NotBlank(message = "새 비밀번호를 입력해주세요.")
+    @Pattern(regexp = PasswordValidation.REGEX, message = PasswordValidation.MESSAGE)
+    private String newPassword;
+
+    @Schema(description = "새 비밀번호 확인", example = "Password1!")
+    @NotBlank(message = "새 비밀번호 확인을 입력해주세요.")
+    private String confirmPassword;
+}

--- a/src/main/java/com/afternote/domain/auth/dto/PasswordValidation.java
+++ b/src/main/java/com/afternote/domain/auth/dto/PasswordValidation.java
@@ -1,0 +1,13 @@
+package com.afternote.domain.auth.dto;
+
+public final class PasswordValidation {
+
+    public static final String REGEX =
+            "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,15}$";
+
+    public static final String MESSAGE =
+            "비밀번호는 8~15자의 영문, 숫자, 특수문자를 포함해야 합니다.";
+
+    private PasswordValidation() {
+    }
+}

--- a/src/main/java/com/afternote/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/afternote/domain/auth/dto/SignupRequest.java
@@ -17,8 +17,7 @@ public class SignupRequest {
     private String email;
 
     @Schema(description = "비밀번호", example = "password123!")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
-            message = "비밀번호는 8~20자의 영문 대소문자, 숫자, 특수문자를 포함해야 합니다.")
+    @Pattern(regexp = PasswordValidation.REGEX, message = PasswordValidation.MESSAGE)
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 

--- a/src/main/java/com/afternote/domain/auth/service/AuthService.java
+++ b/src/main/java/com/afternote/domain/auth/service/AuthService.java
@@ -136,14 +136,83 @@ public class AuthService {
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
         }
-        emailService.sendCode(request.getEmail());
+        emailService.sendCode(request.getEmail(), EmailVerificationPurpose.SIGNUP);
     }
 
     @Transactional
     public void emailVerify(EmailVerifyRequest request) {
-        if(!emailService.verifyCode(request.getEmail(), request.getCertificateCode())){
+        if (!emailService.verifyCode(
+                request.getEmail(),
+                request.getCertificateCode(),
+                EmailVerificationPurpose.SIGNUP
+        )) {
             throw new CustomException(ErrorCode.INVALID_EMAIL_VERIFICATION);
         }
+    }
+
+    @Transactional
+    public void findSendCode(FindSendCodeRequest request) {
+        findActiveLocalUserForRecovery(request.getEmail());
+        emailService.sendCode(request.getEmail(), EmailVerificationPurpose.FIND);
+    }
+
+    @Transactional
+    public EmailFindResponse findEmail(EmailFindRequest request) {
+        User user = findActiveLocalUserForRecovery(request.getEmail());
+
+        if (!emailService.verifyAndDeleteCode(
+                request.getEmail(),
+                request.getCertificateCode(),
+                EmailVerificationPurpose.FIND
+        )) {
+            throw new CustomException(ErrorCode.INVALID_EMAIL_VERIFICATION);
+        }
+
+        return EmailFindResponse.from(user.getName(), user.getEmail());
+    }
+
+    @Transactional
+    public void findPassword(PasswordFindRequest request) {
+        if (!request.getNewPassword().equals(request.getConfirmPassword())) {
+            throw new CustomException(ErrorCode.PASSWORD_CONFIRM_MISMATCH);
+        }
+
+        User user = findActiveLocalUserForRecovery(request.getEmail());
+
+        if (!emailService.verifyAndDeleteCode(
+                request.getEmail(),
+                request.getCertificateCode(),
+                EmailVerificationPurpose.FIND
+        )) {
+            throw new CustomException(ErrorCode.INVALID_EMAIL_VERIFICATION);
+        }
+
+        if (passwordEncoder.matches(request.getNewPassword(), user.getPassword())) {
+            throw new CustomException(ErrorCode.NEWPASSWORD_MATCH);
+        }
+
+        user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
+    }
+
+    private User findActiveUserForAccountRecovery(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.EMAIL_NOT_REGISTERED));
+
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new CustomException(ErrorCode.EMAIL_NOT_REGISTERED);
+        }
+
+        return user;
+    }
+
+    private User findActiveLocalUserForRecovery(String email) {
+        User user = findActiveUserForAccountRecovery(email);
+
+        if (user.getPassword() == null) {
+            throw new CustomException(ErrorCode.SOCIAL_LOGIN_USER);
+        }
+
+        return user;
     }
 
     /**

--- a/src/main/java/com/afternote/domain/auth/service/EmailService.java
+++ b/src/main/java/com/afternote/domain/auth/service/EmailService.java
@@ -25,24 +25,21 @@ public class EmailService {
     private static final long MAX_SENDS_PER_HOUR = 5L;
 
     private final JavaMailSender javaMailSender;
-    private final RedisTemplate<String, String> redisTemplate; // 이미 설정해둔 RedisTemplate 사용
-    
+    private final RedisTemplate<String, String> redisTemplate;
+
     @Value("${spring.mail.username}")
     private String senderEmail;
 
-    // 1. 인증번호 전송 로직
-    public void sendCode(String toEmail) {
-        String cooldownKey = COOLDOWN_KEY_PREFIX + toEmail;
+    public void sendCode(String toEmail, EmailVerificationPurpose purpose) {
+        String cooldownKey = COOLDOWN_KEY_PREFIX + purpose.name() + ":" + toEmail;
         String hourlyKey = HOURLY_COUNT_KEY_PREFIX + toEmail;
 
-        // 시간당 발송 한도 체크 (한도 초과 시 쿨다운 락도 잡지 않음)
         String currentCountStr = redisTemplate.opsForValue().get(hourlyKey);
         long currentCount = currentCountStr == null ? 0L : Long.parseLong(currentCountStr);
         if (currentCount >= MAX_SENDS_PER_HOUR) {
             throw new CustomException(ErrorCode.EMAIL_SEND_LIMIT_EXCEEDED);
         }
 
-        // 재전송 쿨다운 (setIfAbsent로 원자적 체크 & 락)
         Boolean acquired = redisTemplate.opsForValue()
                 .setIfAbsent(cooldownKey, "1", RESEND_COOLDOWN);
         if (Boolean.FALSE.equals(acquired)) {
@@ -50,6 +47,7 @@ public class EmailService {
         }
 
         String authCode = createCode();
+        String codeKey = buildCodeKey(toEmail, purpose);
 
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(toEmail);
@@ -60,13 +58,11 @@ public class EmailService {
         try {
             javaMailSender.send(message);
         } catch (RuntimeException e) {
-            // 메일 전송 실패 시 쿨다운 즉시 해제 (사용자 즉시 재시도 허용)
             redisTemplate.delete(cooldownKey);
             throw e;
         }
 
-        // 발송 성공 시에만 인증코드 저장 + 시간당 카운트 증가
-        redisTemplate.opsForValue().set(CODE_KEY_PREFIX + toEmail, authCode, 3, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set(codeKey, authCode, 3, TimeUnit.MINUTES);
 
         Long newCount = redisTemplate.opsForValue().increment(hourlyKey);
         if (newCount != null && newCount == 1L) {
@@ -74,15 +70,27 @@ public class EmailService {
         }
     }
 
-    // 2. 인증번호 검증 로직
-    public boolean verifyCode(String email, String inputCode) {
-        String redisCode = redisTemplate.opsForValue().get(CODE_KEY_PREFIX + email);
-
-        // 코드가 존재하고, 입력한 코드와 일치하면 true
+    public boolean verifyCode(String email, String inputCode, EmailVerificationPurpose purpose) {
+        String redisCode = redisTemplate.opsForValue().get(buildCodeKey(email, purpose));
         return redisCode != null && redisCode.equals(inputCode);
     }
 
-    // 6자리 랜덤 숫자 생성
+    public boolean verifyAndDeleteCode(String email, String inputCode, EmailVerificationPurpose purpose) {
+        String codeKey = buildCodeKey(email, purpose);
+        String redisCode = redisTemplate.opsForValue().get(codeKey);
+
+        if (redisCode == null || !redisCode.equals(inputCode)) {
+            return false;
+        }
+
+        redisTemplate.delete(codeKey);
+        return true;
+    }
+
+    private String buildCodeKey(String email, EmailVerificationPurpose purpose) {
+        return CODE_KEY_PREFIX + purpose.name() + ":" + email;
+    }
+
     private String createCode() {
         Random random = new Random();
         StringBuilder key = new StringBuilder();

--- a/src/main/java/com/afternote/domain/auth/service/EmailVerificationPurpose.java
+++ b/src/main/java/com/afternote/domain/auth/service/EmailVerificationPurpose.java
@@ -1,0 +1,6 @@
+package com.afternote.domain.auth.service;
+
+public enum EmailVerificationPurpose {
+    SIGNUP,
+    FIND
+}

--- a/src/main/java/com/afternote/global/config/WhiteListUrl.java
+++ b/src/main/java/com/afternote/global/config/WhiteListUrl.java
@@ -18,6 +18,9 @@ public enum WhiteListUrl {
     AUTH_SIGNUP("/auth/sign-up"),
     AUTH_LOGIN("/auth/login"),
     AUTH_REISSUE("/auth/reissue"),
+    AUTH_FIND_SEND_CODE("/auth/find/send/code"),
+    AUTH_EMAIL_FIND("/auth/email/find"),
+    AUTH_PASSWORD_FIND("/auth/password/find"),
 
     // 수신자 인증
     RECEIVER_AUTH("/api/receiver-auth/**"),

--- a/src/main/java/com/afternote/global/exception/ErrorCode.java
+++ b/src/main/java/com/afternote/global/exception/ErrorCode.java
@@ -62,7 +62,7 @@ public enum ErrorCode {
     PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, 1202, "아이디 또는 비밀번호가 일치하지 않습니다."),
 
     // 비밀번호 형식 오류
-    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, 1203, "비밀번호는 8자 이상, 영문/숫자/특수문자를 포함해야 합니다."),
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, 1203, "비밀번호는 8~15자의 영문, 숫자, 특수문자를 포함해야 합니다."),
 
     // 닉네임 중복
     DUPLICATE_NAME(HttpStatus.CONFLICT, 1204, "이미 사용 중인 이름입니다."),
@@ -93,6 +93,12 @@ public enum ErrorCode {
 
     // 이메일 인증번호 시간당 발송 한도 초과
     EMAIL_SEND_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, 1217, "이메일 인증번호 발송 한도를 초과했습니다. 잠시 후 다시 시도해주세요."),
+
+    // 비밀번호 확인 불일치
+    PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, 1218, "비밀번호 확인이 일치하지 않습니다."),
+
+    // 가입되지 않은 이메일
+    EMAIL_NOT_REGISTERED(HttpStatus.BAD_REQUEST, 1219, "가입되지 않은 이메일입니다."),
 
     // ======================================
     // 4. 타임레터 관련 오류 (code: 1300 ~ 1399)

--- a/src/test/java/com/afternote/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/afternote/domain/auth/controller/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.afternote.domain.auth.controller;
 
+import com.afternote.domain.auth.dto.EmailFindResponse;
 import com.afternote.domain.auth.dto.LoginResponse;
 import com.afternote.domain.auth.dto.ReissueResponse;
 import com.afternote.domain.auth.dto.SocialLoginResponse;
@@ -238,6 +239,68 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.data.accessToken").value("social-access"));
 
         verify(authService).socialLogin(any());
+    }
+
+    @Test
+    @DisplayName("아이디/비밀번호 찾기 인증번호 발송 API")
+    void findSendCode_Success() throws Exception {
+        String requestBody = """
+                {
+                  "email": "test@test.com"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/auth/find/send/code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
+
+        verify(authService).findSendCode(any());
+    }
+
+    @Test
+    @DisplayName("아이디 찾기 API - 인증 성공")
+    void findEmail_Verify_Success() throws Exception {
+        given(authService.findEmail(any()))
+                .willReturn(EmailFindResponse.from("tester", "test@test.com"));
+
+        String requestBody = """
+                {
+                  "email": "test@test.com",
+                  "certificateCode": "123456"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/auth/email/find")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.email").value("test@test.com"))
+                .andExpect(jsonPath("$.data.name").value("tester"));
+
+        verify(authService).findEmail(any());
+    }
+
+    @Test
+    @DisplayName("비밀번호 찾기 API - 재설정 성공")
+    void findPassword_Reset_Success() throws Exception {
+        String requestBody = """
+                {
+                  "email": "test@test.com",
+                  "certificateCode": "123456",
+                  "newPassword": "NewPass1!",
+                  "confirmPassword": "NewPass1!"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/auth/password/find")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
+
+        verify(authService).findPassword(any());
     }
 
     private static class UserIdTestArgumentResolver implements HandlerMethodArgumentResolver {

--- a/src/test/java/com/afternote/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/afternote/domain/auth/service/AuthServiceTest.java
@@ -205,7 +205,7 @@ class AuthServiceTest {
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_EMAIL));
 
-        verify(emailService, org.mockito.Mockito.never()).sendCode(any());
+        verify(emailService, org.mockito.Mockito.never()).sendCode(any(), any());
     }
 
     @Test
@@ -217,7 +217,7 @@ class AuthServiceTest {
 
         authService.emailSend(request);
 
-        verify(emailService).sendCode("new@test.com");
+        verify(emailService).sendCode("new@test.com", EmailVerificationPurpose.SIGNUP);
     }
 
     @Test
@@ -226,7 +226,7 @@ class AuthServiceTest {
         EmailVerifyRequest request = org.mockito.Mockito.mock(EmailVerifyRequest.class);
         given(request.getEmail()).willReturn("test@test.com");
         given(request.getCertificateCode()).willReturn("111111");
-        given(emailService.verifyCode("test@test.com", "111111")).willReturn(false);
+        given(emailService.verifyCode("test@test.com", "111111", EmailVerificationPurpose.SIGNUP)).willReturn(false);
 
         assertThatThrownBy(() -> authService.emailVerify(request))
                 .isInstanceOf(CustomException.class)
@@ -301,5 +301,133 @@ class AuthServiceTest {
         assertThat(response.getRefreshToken()).isEqualTo("existing-refresh");
         verify(userRepository, org.mockito.Mockito.never()).save(any(User.class));
         verify(tokenService).saveToken("existing-refresh", 88L);
+    }
+
+    @Test
+    @DisplayName("아이디/비밀번호 찾기 인증번호 발송 성공")
+    void findSendCode_Success() {
+        FindSendCodeRequest request = org.mockito.Mockito.mock(FindSendCodeRequest.class);
+        given(request.getEmail()).willReturn("test@test.com");
+
+        User user = User.builder()
+                .email("test@test.com")
+                .password("encoded")
+                .name("tester")
+                .status(UserStatus.ACTIVE)
+                .provider(AuthProvider.LOCAL)
+                .build();
+
+        given(userRepository.findByEmail("test@test.com")).willReturn(Optional.of(user));
+
+        authService.findSendCode(request);
+
+        verify(emailService).sendCode("test@test.com", EmailVerificationPurpose.FIND);
+    }
+
+    @Test
+    @DisplayName("아이디 찾기 - 인증 성공")
+    void findEmail_Verify_Success() {
+        EmailFindRequest request = org.mockito.Mockito.mock(EmailFindRequest.class);
+        given(request.getEmail()).willReturn("test@test.com");
+        given(request.getCertificateCode()).willReturn("123456");
+
+        User user = User.builder()
+                .email("test@test.com")
+                .password("encoded")
+                .name("tester")
+                .status(UserStatus.ACTIVE)
+                .provider(AuthProvider.LOCAL)
+                .build();
+
+        given(userRepository.findByEmail("test@test.com")).willReturn(Optional.of(user));
+        given(emailService.verifyAndDeleteCode("test@test.com", "123456", EmailVerificationPurpose.FIND))
+                .willReturn(true);
+
+        EmailFindResponse response = authService.findEmail(request);
+
+        assertThat(response.getName()).isEqualTo("tester");
+        assertThat(response.getEmail()).isEqualTo("test@test.com");
+    }
+
+    @Test
+    @DisplayName("아이디 찾기 실패 - 가입되지 않은 이메일")
+    void findEmail_NotRegistered_Fail() {
+        EmailFindRequest request = org.mockito.Mockito.mock(EmailFindRequest.class);
+        given(request.getEmail()).willReturn("unknown@test.com");
+        given(userRepository.findByEmail("unknown@test.com")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.findEmail(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.EMAIL_NOT_REGISTERED));
+    }
+
+    @Test
+    @DisplayName("비밀번호 찾기 - 재설정 성공")
+    void findPassword_Reset_Success() {
+        PasswordFindRequest request = org.mockito.Mockito.mock(PasswordFindRequest.class);
+        given(request.getEmail()).willReturn("test@test.com");
+        given(request.getCertificateCode()).willReturn("123456");
+        given(request.getNewPassword()).willReturn("NewPass1!");
+        given(request.getConfirmPassword()).willReturn("NewPass1!");
+
+        User user = User.builder()
+                .email("test@test.com")
+                .password("encoded")
+                .name("tester")
+                .status(UserStatus.ACTIVE)
+                .provider(AuthProvider.LOCAL)
+                .build();
+
+        given(userRepository.findByEmail("test@test.com")).willReturn(Optional.of(user));
+        given(emailService.verifyAndDeleteCode("test@test.com", "123456", EmailVerificationPurpose.FIND))
+                .willReturn(true);
+        given(passwordEncoder.matches("NewPass1!", "encoded")).willReturn(false);
+        given(passwordEncoder.encode("NewPass1!")).willReturn("new-encoded");
+
+        authService.findPassword(request);
+
+        assertThat(user.getPassword()).isEqualTo("new-encoded");
+    }
+
+    @Test
+    @DisplayName("아이디/비밀번호 찾기 실패 - 소셜 계정")
+    void findSendCode_SocialUser_Fail() {
+        FindSendCodeRequest request = org.mockito.Mockito.mock(FindSendCodeRequest.class);
+        given(request.getEmail()).willReturn("social@test.com");
+
+        User socialUser = User.builder()
+                .email("social@test.com")
+                .password(null)
+                .name("social")
+                .status(UserStatus.ACTIVE)
+                .provider(AuthProvider.KAKAO)
+                .build();
+
+        given(userRepository.findByEmail("social@test.com")).willReturn(Optional.of(socialUser));
+
+        assertThatThrownBy(() -> authService.findSendCode(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.SOCIAL_LOGIN_USER));
+    }
+
+    @Test
+    @DisplayName("아이디 찾기 실패 - 소셜 계정")
+    void findEmail_SocialUser_Fail() {
+        EmailFindRequest request = org.mockito.Mockito.mock(EmailFindRequest.class);
+        given(request.getEmail()).willReturn("social@test.com");
+
+        User socialUser = User.builder()
+                .email("social@test.com")
+                .password(null)
+                .name("social")
+                .status(UserStatus.ACTIVE)
+                .provider(AuthProvider.KAKAO)
+                .build();
+
+        given(userRepository.findByEmail("social@test.com")).willReturn(Optional.of(socialUser));
+
+        assertThatThrownBy(() -> authService.findEmail(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.SOCIAL_LOGIN_USER));
     }
 }


### PR DESCRIPTION
Separate shared verification send from find/reset flows and align password validation to 8-15 characters.

## 📌 관련 이슈
close #

## ✨ 작업 내용
-

## 🛠️ 테스트 계획 및 결과
- [ ] 로컬 API 테스트(Postman/Swagger) 완료
- [ ] API 테스트(Postman/Swagger) 완료

## 📚 체크리스트
- [ ] 브랜치 전략에 맞는 브랜치인가요? (`[이름]/[타입]/[기능]`)
- [ ] 커밋 메시지 컨벤션을 준수했나요? (`[타입] 제목`)
- [ ] 불필요한 주석이나 print문은 제거했나요?

## 스크린샷 (선택)


## 💬 리뷰어에게 (선택)