### PR TITLE
fix: 500 응답에서 내부 예외 메시지 노출 제거

### DIFF
--- a/src/main/java/com/afternote/global/exception/ErrorCode.java
+++ b/src/main/java/com/afternote/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, 1001, "인증이 필요합니다. 로그인해주세요."),
     NOT_ENOUGH_PERMISSION(HttpStatus.FORBIDDEN, 1002, "권한이 부족합니다."),
     ENDPOINT_NOT_FOUND(HttpStatus.NOT_FOUND, 1003, "존재하지 않는 엔드포인트입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 1004, "서버 내부 오류가 발생했습니다."),
 
     // ======================================
     // 2. 토큰 관련 오류 (code: 1100 ~ 1199)

--- a/src/main/java/com/afternote/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/afternote/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.afternote.global.exception;
 
 import com.afternote.global.common.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -44,12 +46,14 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(400, 400, "요청 파라미터 형식이 올바르지 않습니다."));
     }
 
-    // 5. 그 외 예상치 못한 에러 (NullPointer 등)
+    // 5. 그 외 예상치 못한 에러 — 상세는 로그에만, 응답은 일반 메시지
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unhandled exception", e);
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
         return ResponseEntity
-                .status(500)
-                .body(ApiResponse.error(500, 500, "서버 내부 오류: " + e.getMessage()));
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.error(errorCode));
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,6 +54,11 @@ google:
 
 server:
   port: ${SERVER_PORT:8080}
+  error:
+    include-message: never
+    include-binding-errors: never
+    include-stacktrace: never
+    include-exception: false
 
 logging:
   level:


### PR DESCRIPTION
## 📌 관련 이슈
close #

## ✨ 작업 내용
-

## 🛠️ 테스트 계획 및 결과
- [ ] 로컬 API 테스트(Postman/Swagger) 완료
- [ ] API 테스트(Postman/Swagger) 완료

## 📚 체크리스트
- [ ] 브랜치 전략에 맞는 브랜치인가요? (`[이름]/[타입]/[기능]`)
- [ ] 커밋 메시지 컨벤션을 준수했나요? (`[타입] 제목`)
- [ ] 불필요한 주석이나 print문은 제거했나요?

## 스크린샷 (선택)


## 💬 리뷰어에게 (선택)