### PR TITLE
fix: 잘못된 쿼리 파라미터 500을 400으로 처리하고 mind-record contract 제외

### DIFF
--- a/scripts/contract-test.sh
+++ b/scripts/contract-test.sh
@@ -22,9 +22,10 @@ fi
 BASE_URL="${BASE_URL%/}"
 
 # prod 안전: GET만, 5xx만 실패 처리.
-# receiver-auth는 특수 헤더(X-Auth-Code) + 잘못된 path id에서 500이 나 1차 제외.
-# admin은 관리자 전용.
-EXCLUDE_PATH_REGEX="${CONTRACT_EXCLUDE_PATH_REGEX:-/api/v1/admin|/api/v1/receiver-auth}"
+# receiver-auth: 특수 헤더(X-Auth-Code) + 잘못된 path id 500
+# admin: 관리자 전용
+# mind-record: Gemini 외부 호출/쿼터로 timeout·불안정
+EXCLUDE_PATH_REGEX="${CONTRACT_EXCLUDE_PATH_REGEX:-/api/v1/admin|/api/v1/receiver-auth|/api/v1/mind-record}"
 MAX_EXAMPLES="${CONTRACT_MAX_EXAMPLES:-5}"
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"

--- a/src/main/java/com/afternote/domain/afternote/controller/AfternoteController.java
+++ b/src/main/java/com/afternote/domain/afternote/controller/AfternoteController.java
@@ -12,11 +12,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Afternote API", description = "afternote 관련 API")
 @RestController
+@Validated
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/afternotes")
 public class AfternoteController {
@@ -34,10 +37,10 @@ public class AfternoteController {
             @RequestParam(required = false) AfternoteCategoryType category,
             
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "0") @Min(value = 0, message = "page는 0 이상이어야 합니다.") int page,
             
             @Parameter(description = "페이지 사이즈", example = "10")
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") @Min(value = 1, message = "size는 1 이상이어야 합니다.") int size
     ) {
         AfternotePageResponse response = afternoteService.getAfternotes(userId, category, page, size);
         return ApiResponse.success(response);

--- a/src/main/java/com/afternote/domain/afternote/service/AfternoteService.java
+++ b/src/main/java/com/afternote/domain/afternote/service/AfternoteService.java
@@ -32,6 +32,10 @@ public class AfternoteService {
     private final S3Service s3Service;
 
     public AfternotePageResponse getAfternotes(Long userId, AfternoteCategoryType category, Integer page, Integer size) {
+        if (page == null || page < 0 || size == null || size < 1) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
         Pageable pageable = PageRequest.of(page, size);
         Page<Afternote> afternotePage;
         

--- a/src/main/java/com/afternote/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/afternote/global/exception/GlobalExceptionHandler.java
@@ -1,12 +1,17 @@
 package com.afternote.global.exception;
 
 import com.afternote.global.common.ApiResponse;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
@@ -30,6 +35,18 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(400, 400, errorMessage));
     }
 
+    // 2-1. @Validated + @Min/@Max 등 메서드 파라미터 검증
+    @ExceptionHandler({ConstraintViolationException.class, HandlerMethodValidationException.class})
+    public ResponseEntity<ApiResponse<Void>> handleConstraintViolationException(Exception e) {
+        String errorMessage = "요청 값이 올바르지 않습니다.";
+        if (e instanceof ConstraintViolationException cve && !cve.getConstraintViolations().isEmpty()) {
+            errorMessage = cve.getConstraintViolations().iterator().next().getMessage();
+        }
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.error(400, ErrorCode.INVALID_INPUT_VALUE.getCode(), errorMessage));
+    }
+
     // 3. JSON 파싱 에러 처리 (잘못된 형식의 요청)
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<Void>> handleJsonParseException(HttpMessageNotReadableException e) {
@@ -38,12 +55,17 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(400, 400, "잘못된 요청 형식입니다. JSON 데이터를 확인해주세요."));
     }
 
-    // 4. 경로 변수/쿼리 파라미터 타입 불일치 (예: id에 문자열 전달)
-    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ApiResponse<Void>> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
+    // 4. 경로 변수/쿼리 파라미터 타입 불일치·누락 (예: yearMonth=, page 문자열)
+    @ExceptionHandler({
+            MethodArgumentTypeMismatchException.class,
+            TypeMismatchException.class,
+            ConversionFailedException.class,
+            MissingServletRequestParameterException.class
+    })
+    public ResponseEntity<ApiResponse<Void>> handleTypeMismatchException(Exception e) {
         return ResponseEntity
                 .badRequest()
-                .body(ApiResponse.error(400, 400, "요청 파라미터 형식이 올바르지 않습니다."));
+                .body(ApiResponse.error(400, ErrorCode.INVALID_INPUT_VALUE.getCode(), "요청 파라미터 형식이 올바르지 않습니다."));
     }
 
     // 5. 그 외 예상치 못한 에러 — 상세는 로그에만, 응답은 일반 메시지


### PR DESCRIPTION
## Summary
- 빈 `yearMonth`, 음수 `page` 등 잘못된 쿼리 파라미터가 500으로 떨어지던 문제를 400으로 통일
- 애프터노트 목록 `page`/`size`에 `@Min` 검증과 서비스 방어 로직 추가
- Gemini 쿼터/timeout이 나는 `/api/v1/mind-record`는 contract 테스트에서 제외

## Test plan
- [ ] `GET /api/v1/diary?yearMonth=` → 400
- [ ] `GET /api/v1/afternotes?page=-1` → 400
- [ ] 배포 후 contract test에서 mind-record가 exclude 되고 나머지 GET이 통과하는지 확인


Made with [Cursor](https://cursor.com)