### PR TITLE
fix: 애프터노트 목록 page/size 상한 검증으로 offset 오버플로우 500 방지

### DIFF
--- a/src/main/java/com/afternote/domain/afternote/controller/AfternoteController.java
+++ b/src/main/java/com/afternote/domain/afternote/controller/AfternoteController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
@@ -37,10 +38,16 @@ public class AfternoteController {
             @RequestParam(required = false) AfternoteCategoryType category,
             
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
-            @RequestParam(defaultValue = "0") @Min(value = 0, message = "page는 0 이상이어야 합니다.") int page,
+            @RequestParam(defaultValue = "0")
+            @Min(value = 0, message = "page는 0 이상이어야 합니다.")
+            @Max(value = 10_000, message = "page가 너무 큽니다.")
+            int page,
             
             @Parameter(description = "페이지 사이즈", example = "10")
-            @RequestParam(defaultValue = "10") @Min(value = 1, message = "size는 1 이상이어야 합니다.") int size
+            @RequestParam(defaultValue = "10")
+            @Min(value = 1, message = "size는 1 이상이어야 합니다.")
+            @Max(value = 100, message = "size는 100 이하여야 합니다.")
+            int size
     ) {
         AfternotePageResponse response = afternoteService.getAfternotes(userId, category, page, size);
         return ApiResponse.success(response);

--- a/src/main/java/com/afternote/domain/afternote/service/AfternoteService.java
+++ b/src/main/java/com/afternote/domain/afternote/service/AfternoteService.java
@@ -35,6 +35,10 @@ public class AfternoteService {
         if (page == null || page < 0 || size == null || size < 1) {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
+        // PageRequest offset(page * size)가 int 범위를 넘으면 IllegalArgumentException → 500 방지
+        if ((long) page * (long) size > Integer.MAX_VALUE) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
 
         Pageable pageable = PageRequest.of(page, size);
         Page<Afternote> afternotePage;


### PR DESCRIPTION
## Summary
- `page`/`size`에 상한(`@Max`)을 두고, `page * size`가 int 범위를 넘으면 400 반환
- contract가 보낸 `page=214748365`처럼 극단값에서 500이 나던 문제 수정

## Test plan
- [ ] `GET /api/v1/afternotes?page=214748365` → 400
- [ ] `GET /api/v1/afternotes?page=0&size=10` → 200
- [ ] 배포 후 contract test 통과 확인


Made with [Cursor](https://cursor.com)