### PR TITLE
feat: 이메일 인증번호 발송 응답에 expiresAt 추가 (#77)

### DIFF
--- a/src/main/java/com/afternote/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/afternote/domain/auth/controller/AuthController.java
@@ -66,13 +66,12 @@ public class AuthController {
         return ApiResponse.success(null);
     }
 
-    @Operation(summary = "이메일 인증번호 전송 API", description = "이메일을 입력해 인증번호를 받습니다.")
+    @Operation(summary = "이메일 인증번호 전송 API", description = "이메일을 입력해 인증번호를 받습니다. 응답의 expiresAt으로 입력 화면 만료 카운트다운을 맞춥니다.")
     @PostMapping("/email/send")
-    public ApiResponse<Object> emailSend(
+    public ApiResponse<EmailSendResponse> emailSend(
             @Valid @RequestBody  EmailSendRequest emailSendRequest
     ) {
-        authService.emailSend(emailSendRequest);
-        return ApiResponse.success(null);
+        return ApiResponse.success(authService.emailSend(emailSendRequest));
     }
 
     @Operation(summary = "이메일 인증번호 검증 API", description = "이메일과 인증코드를 통해 검증받습니다.")
@@ -86,14 +85,13 @@ public class AuthController {
 
     @Operation(
             summary = "아이디/비밀번호 찾기 인증번호 발송 API",
-            description = "로컬(이메일) 계정의 아이디/비밀번호 찾기용 인증번호를 발송합니다."
+            description = "로컬(이메일) 계정의 아이디/비밀번호 찾기용 인증번호를 발송합니다. 응답의 expiresAt으로 입력 화면 만료 카운트다운을 맞춥니다."
     )
     @PostMapping("/find/send/code")
-    public ApiResponse<Object> findSendCode(
+    public ApiResponse<EmailSendResponse> findSendCode(
             @Valid @RequestBody FindSendCodeRequest findSendCodeRequest
     ) {
-        authService.findSendCode(findSendCodeRequest);
-        return ApiResponse.success(null);
+        return ApiResponse.success(authService.findSendCode(findSendCodeRequest));
     }
 
     @Operation(

--- a/src/main/java/com/afternote/domain/auth/dto/EmailSendResponse.java
+++ b/src/main/java/com/afternote/domain/auth/dto/EmailSendResponse.java
@@ -1,0 +1,20 @@
+package com.afternote.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Builder
+public record EmailSendResponse(
+        @Schema(description = "인증번호 만료 시각 (UTC)", example = "2026-07-06T13:45:30Z")
+        @Getter
+        Instant expiresAt
+) {
+    public static EmailSendResponse of(Instant expiresAt) {
+        return EmailSendResponse.builder()
+                .expiresAt(expiresAt)
+                .build();
+    }
+}

--- a/src/main/java/com/afternote/domain/auth/service/AuthService.java
+++ b/src/main/java/com/afternote/domain/auth/service/AuthService.java
@@ -141,11 +141,13 @@ public class AuthService {
     }
 
     @Transactional
-    public void emailSend(EmailSendRequest request) {
+    public EmailSendResponse emailSend(EmailSendRequest request) {
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
         }
-        emailService.sendCode(request.getEmail(), EmailVerificationPurpose.SIGNUP);
+        return EmailSendResponse.of(
+                emailService.sendCode(request.getEmail(), EmailVerificationPurpose.SIGNUP)
+        );
     }
 
     @Transactional
@@ -161,9 +163,11 @@ public class AuthService {
     }
 
     @Transactional
-    public void findSendCode(FindSendCodeRequest request) {
+    public EmailSendResponse findSendCode(FindSendCodeRequest request) {
         findActiveLocalUserForRecovery(request.getEmail());
-        emailService.sendCode(request.getEmail(), EmailVerificationPurpose.FIND);
+        return EmailSendResponse.of(
+                emailService.sendCode(request.getEmail(), EmailVerificationPurpose.FIND)
+        );
     }
 
     @Transactional

--- a/src/main/java/com/afternote/domain/auth/service/EmailService.java
+++ b/src/main/java/com/afternote/domain/auth/service/EmailService.java
@@ -10,8 +10,8 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Random;
-import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +23,7 @@ public class EmailService {
     private static final String HOURLY_COUNT_KEY_PREFIX = "EMAIL_SEND_COUNT:";
     private static final Duration RESEND_COOLDOWN = Duration.ofSeconds(10);
     private static final Duration HOURLY_LIMIT_WINDOW = Duration.ofHours(1);
+    private static final Duration CODE_TTL = Duration.ofMinutes(3);
     private static final Duration VERIFIED_TTL = Duration.ofMinutes(10);
     private static final long MAX_SENDS_PER_HOUR = 5L;
 
@@ -32,7 +33,11 @@ public class EmailService {
     @Value("${spring.mail.username}")
     private String senderEmail;
 
-    public void sendCode(String toEmail, EmailVerificationPurpose purpose) {
+    /**
+     * 인증번호를 발송하고 Redis에 저장한다.
+     * @return 인증번호 만료 시각 (UTC)
+     */
+    public Instant sendCode(String toEmail, EmailVerificationPurpose purpose) {
         String cooldownKey = COOLDOWN_KEY_PREFIX + purpose.name() + ":" + toEmail;
         String hourlyKey = HOURLY_COUNT_KEY_PREFIX + toEmail;
 
@@ -54,7 +59,8 @@ public class EmailService {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(toEmail);
         message.setSubject("[AfterNote] 이메일 인증 번호입니다.");
-        message.setText("인증 번호는 [" + authCode + "] 입니다. 3분 안에 입력해주세요.");
+        message.setText("인증 번호는 [" + authCode + "] 입니다. "
+                + CODE_TTL.toMinutes() + "분 안에 입력해주세요.");
         message.setFrom(senderEmail);
 
         try {
@@ -64,12 +70,15 @@ public class EmailService {
             throw e;
         }
 
-        redisTemplate.opsForValue().set(codeKey, authCode, 3, TimeUnit.MINUTES);
+        Instant expiresAt = Instant.now().plus(CODE_TTL);
+        redisTemplate.opsForValue().set(codeKey, authCode, CODE_TTL);
 
         Long newCount = redisTemplate.opsForValue().increment(hourlyKey);
         if (newCount != null && newCount == 1L) {
             redisTemplate.expire(hourlyKey, HOURLY_LIMIT_WINDOW);
         }
+
+        return expiresAt;
     }
 
     public boolean verifyCode(String email, String inputCode, EmailVerificationPurpose purpose) {

--- a/src/main/java/com/afternote/domain/receiver/controller/ReceiverAuthController.java
+++ b/src/main/java/com/afternote/domain/receiver/controller/ReceiverAuthController.java
@@ -201,14 +201,13 @@ public class ReceiverAuthController {
 
     @Operation(
             summary = "수신자 이메일 인증번호 발송",
-            description = "수신자 이메일로 6자리 인증번호를 발송합니다."
+            description = "수신자 이메일로 6자리 인증번호를 발송합니다. 응답의 expiresAt으로 입력 화면 만료 카운트다운을 맞춥니다."
     )
     @PostMapping("/email/auth-code")
-    public ApiResponse<Void> sendEmailAuthCode(
+    public ApiResponse<ReceiverEmailAuthCodeSendResponse> sendEmailAuthCode(
             @Valid @RequestBody ReceiverAuthCodeEmailSendRequest request
     ) {
-        receiverAuthService.sendEmailAuthCode(request.getEmail());
-        return ApiResponse.success(null);
+        return ApiResponse.success(receiverAuthService.sendEmailAuthCode(request.getEmail()));
     }
 
     @Operation(

--- a/src/main/java/com/afternote/domain/receiver/dto/ReceiverEmailAuthCodeSendResponse.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/ReceiverEmailAuthCodeSendResponse.java
@@ -1,0 +1,20 @@
+package com.afternote.domain.receiver.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Builder
+public record ReceiverEmailAuthCodeSendResponse(
+        @Schema(description = "인증번호 만료 시각 (UTC)", example = "2026-07-06T13:45:30Z")
+        @Getter
+        Instant expiresAt
+) {
+    public static ReceiverEmailAuthCodeSendResponse of(Instant expiresAt) {
+        return ReceiverEmailAuthCodeSendResponse.builder()
+                .expiresAt(expiresAt)
+                .build();
+    }
+}

--- a/src/main/java/com/afternote/domain/receiver/service/ReceiverAuthService.java
+++ b/src/main/java/com/afternote/domain/receiver/service/ReceiverAuthService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -127,7 +128,7 @@ public class ReceiverAuthService {
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_AUTH_CODE));
     }
 
-    public void sendEmailAuthCode(String email) {
+    public ReceiverEmailAuthCodeSendResponse sendEmailAuthCode(String email) {
         String normalizedEmail = normalizeEmail(email);
 
         List<Receiver> receivers =
@@ -146,6 +147,7 @@ public class ReceiverAuthService {
 
         String redisKey = EMAIL_AUTH_CODE_PREFIX + normalizedEmail;
         String redisValue = receiver.getId() + ":" + emailAuthCode;
+        Instant expiresAt = Instant.now().plus(EMAIL_AUTH_CODE_TTL);
 
         try {
             stringRedisTemplate.opsForValue().set(
@@ -164,6 +166,8 @@ public class ReceiverAuthService {
             stringRedisTemplate.delete(redisKey);
             throw new CustomException(ErrorCode.RECEIVER_EMAIL_SEND_FAILED);
         }
+
+        return ReceiverEmailAuthCodeSendResponse.of(expiresAt);
     }
 
     public ReceiverEmailAuthVerifyResponse verifyEmailAuthCode(String email, String inputAuthCode) {

--- a/src/test/java/com/afternote/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/afternote/domain/auth/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.afternote.domain.auth.controller;
 
 import com.afternote.domain.auth.dto.EmailFindResponse;
+import com.afternote.domain.auth.dto.EmailSendResponse;
 import com.afternote.domain.auth.dto.LoginResponse;
 import com.afternote.domain.auth.dto.ReissueResponse;
 import com.afternote.domain.auth.dto.SocialLoginResponse;
@@ -8,6 +9,9 @@ import com.afternote.domain.auth.service.AuthService;
 import com.afternote.domain.user.model.User;
 import com.afternote.global.resolver.UserId;
 import com.afternote.global.resolver.UserIdArgumentResolver;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -47,8 +52,12 @@ class AuthControllerTest {
 
     @BeforeEach
     void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         this.mockMvc = MockMvcBuilders.standaloneSetup(authController)
                 .setCustomArgumentResolvers(new UserIdTestArgumentResolver())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
                 .build();
     }
 
@@ -190,6 +199,9 @@ class AuthControllerTest {
     @Test
     @DisplayName("이메일 인증번호 전송 API 성공")
     void emailSend_Success() throws Exception {
+        given(authService.emailSend(any()))
+                .willReturn(EmailSendResponse.of(java.time.Instant.parse("2026-07-06T13:45:30Z")));
+
         String requestBody = """
                 {
                   "email": "test@test.com"
@@ -200,7 +212,8 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value(200));
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.expiresAt").value("2026-07-06T13:45:30Z"));
 
         verify(authService).emailSend(any());
     }
@@ -256,6 +269,9 @@ class AuthControllerTest {
     @Test
     @DisplayName("아이디/비밀번호 찾기 인증번호 발송 API")
     void findSendCode_Success() throws Exception {
+        given(authService.findSendCode(any()))
+                .willReturn(EmailSendResponse.of(java.time.Instant.parse("2026-07-06T13:45:30Z")));
+
         String requestBody = """
                 {
                   "email": "test@test.com"
@@ -266,7 +282,8 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value(200));
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.expiresAt").value("2026-07-06T13:45:30Z"));
 
         verify(authService).findSendCode(any());
     }

--- a/src/test/java/com/afternote/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/afternote/domain/auth/service/AuthServiceTest.java
@@ -233,9 +233,12 @@ class AuthServiceTest {
         EmailSendRequest request = org.mockito.Mockito.mock(EmailSendRequest.class);
         given(request.getEmail()).willReturn("new@test.com");
         given(userRepository.existsByEmail("new@test.com")).willReturn(false);
+        java.time.Instant expiresAt = java.time.Instant.parse("2026-07-06T13:45:30Z");
+        given(emailService.sendCode("new@test.com", EmailVerificationPurpose.SIGNUP)).willReturn(expiresAt);
 
-        authService.emailSend(request);
+        EmailSendResponse response = authService.emailSend(request);
 
+        assertThat(response.getExpiresAt()).isEqualTo(expiresAt);
         verify(emailService).sendCode("new@test.com", EmailVerificationPurpose.SIGNUP);
     }
 
@@ -354,9 +357,12 @@ class AuthServiceTest {
                 .build();
 
         given(userRepository.findByEmail("test@test.com")).willReturn(Optional.of(user));
+        java.time.Instant expiresAt = java.time.Instant.parse("2026-07-06T13:45:30Z");
+        given(emailService.sendCode("test@test.com", EmailVerificationPurpose.FIND)).willReturn(expiresAt);
 
-        authService.findSendCode(request);
+        EmailSendResponse response = authService.findSendCode(request);
 
+        assertThat(response.getExpiresAt()).isEqualTo(expiresAt);
         verify(emailService).sendCode("test@test.com", EmailVerificationPurpose.FIND);
     }
 

--- a/src/test/java/com/afternote/domain/receiver/controller/ReceiverAuthControllerTest.java
+++ b/src/test/java/com/afternote/domain/receiver/controller/ReceiverAuthControllerTest.java
@@ -1,6 +1,10 @@
 package com.afternote.domain.receiver.controller;
 
+import com.afternote.domain.receiver.dto.ReceiverEmailAuthCodeSendResponse;
 import com.afternote.domain.receiver.service.ReceiverAuthService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,14 +13,18 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.Instant;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,7 +42,12 @@ class ReceiverAuthControllerTest {
 
     @BeforeEach
     void setUp() {
-        mockMvc = MockMvcBuilders.standaloneSetup(receiverAuthController).build();
+        ObjectMapper objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mockMvc = MockMvcBuilders.standaloneSetup(receiverAuthController)
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
     }
 
     @Test
@@ -152,5 +165,20 @@ class ReceiverAuthControllerTest {
                 .andExpect(status().isOk());
 
         verify(receiverAuthService).getDeliveryVerificationStatus(AUTH_CODE);
+    }
+
+    @Test
+    @DisplayName("수신자 이메일 인증번호 발송 API 성공")
+    void sendEmailAuthCode_Success() throws Exception {
+        given(receiverAuthService.sendEmailAuthCode("receiver@test.com"))
+                .willReturn(ReceiverEmailAuthCodeSendResponse.of(Instant.parse("2026-07-06T13:45:30Z")));
+
+        mockMvc.perform(post("/api/v1/receiver-auth/email/auth-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"receiver@test.com\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.expiresAt").value("2026-07-06T13:45:30Z"));
+
+        verify(receiverAuthService).sendEmailAuthCode("receiver@test.com");
     }
 }


### PR DESCRIPTION
## Summary
- `POST /auth/email/send`, `POST /auth/find/send/code` 응답 `data`에 `expiresAt`(UTC Instant) 추가 — 회원/찾기 인증번호 TTL 3분
- `POST /receiver-auth/email/auth-code` 응답에도 동일 필드 추가 — 수신자 본인확인 TTL 5분
- FE가 하드코딩 타이머 대신 응답값으로 만료 카운트다운을 맞출 수 있음

## Test plan
- [ ] `POST /api/v1/auth/email/send` 성공 시 `data.expiresAt`이 ISO-8601 UTC(`...Z`)로 오는지 확인
- [ ] 발송 직후 시각 + 3분과 `expiresAt`이 대략 일치하는지 확인
- [ ] `POST /api/v1/receiver-auth/email/auth-code`는 +5분 기준으로 확인
- [ ] `POST /api/v1/auth/find/send/code`도 `expiresAt` 포함 여부 확인
- [ ] 관련 단위 테스트 통과 확인

Closes #77


Made with [Cursor](https://cursor.com)