### PR TITLE
feat: leaveMessage를 {title, body} 블록 배열로 확장 (#78)

### DIFF
--- a/src/main/java/com/afternote/domain/afternote/dto/AfternoteCreateRequest.java
+++ b/src/main/java/com/afternote/domain/afternote/dto/AfternoteCreateRequest.java
@@ -2,6 +2,7 @@ package com.afternote.domain.afternote.dto;
 
 import com.afternote.domain.afternote.model.AfternoteCategoryType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -23,9 +24,10 @@ public record AfternoteCreateRequest(
         @Getter
         List<String> actions,
 
-        @Schema(description = "남기신 말씀 (SOCIAL/GALLERY 전용)")
+        @Schema(description = "남기실 말씀 블록 목록 (제목+본문). 모든 카테고리에서 사용 가능")
         @Getter
-        String leaveMessage,
+        @Valid
+        List<LeaveMessageBlock> leaveMessage,
 
         @Schema(description = "계정 정보 (SOCIAL 전용)")
         @Getter

--- a/src/main/java/com/afternote/domain/afternote/dto/AfternotedetailResponse.java
+++ b/src/main/java/com/afternote/domain/afternote/dto/AfternotedetailResponse.java
@@ -24,9 +24,9 @@ public record AfternotedetailResponse(
         @Getter
         List<String> actions,
 
-        @Schema(description = "남기신 말씀 (SOCIAL/GALLERY 전용)")
+        @Schema(description = "남기실 말씀 블록 목록 (제목+본문)")
         @Getter
-        String leaveMessage,
+        List<LeaveMessageBlock> leaveMessage,
 
         @Schema(description = "계정 정보 (SOCIAL 전용)")
         @Getter

--- a/src/main/java/com/afternote/domain/afternote/dto/LeaveMessageBlock.java
+++ b/src/main/java/com/afternote/domain/afternote/dto/LeaveMessageBlock.java
@@ -1,0 +1,17 @@
+package com.afternote.domain.afternote.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+public record LeaveMessageBlock(
+        @Schema(description = "남기실 말씀 제목 (선택)", example = "남긴말1")
+        @Getter
+        String title,
+
+        @Schema(description = "남기실 말씀 본문", example = "언제나 고맙고 사랑한다.")
+        @Getter
+        String body
+) {
+}

--- a/src/main/java/com/afternote/domain/afternote/model/Afternote.java
+++ b/src/main/java/com/afternote/domain/afternote/model/Afternote.java
@@ -1,5 +1,6 @@
 package com.afternote.domain.afternote.model;
 
+import com.afternote.domain.afternote.dto.LeaveMessageBlock;
 import com.afternote.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -32,8 +33,9 @@ public class Afternote extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String title;
     
+    @Convert(converter = LeaveMessageListConverter.class)
     @Column(columnDefinition = "TEXT")
-    private String leaveMessage;
+    private List<LeaveMessageBlock> leaveMessage;
 
     @Column(name = "sort_order")
     private Integer sortOrder;
@@ -56,7 +58,7 @@ public class Afternote extends BaseEntity {
     private AfternotePlaylist playlist;
 
     // 업데이트 메서드
-    public void update(String title, Integer sortOrder, String leaveMessage,List<String> actions) {
+    public void update(String title, Integer sortOrder, List<LeaveMessageBlock> leaveMessage, List<String> actions) {
         this.title = title;
         this.sortOrder = sortOrder;
         this.leaveMessage = leaveMessage;

--- a/src/main/java/com/afternote/domain/afternote/model/LeaveMessageListConverter.java
+++ b/src/main/java/com/afternote/domain/afternote/model/LeaveMessageListConverter.java
@@ -1,0 +1,65 @@
+package com.afternote.domain.afternote.model;
+
+import com.afternote.domain.afternote.dto.LeaveMessageBlock;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * leave_message TEXT 컬럼에 JSON 배열 문자열로 저장한다.
+ * 레거시 plain string은 [{title:"", body:원문}] 으로 감싸 읽는다.
+ */
+@Converter
+public class LeaveMessageListConverter implements AttributeConverter<List<LeaveMessageBlock>, String> {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<List<LeaveMessageBlock>> TYPE =
+            new TypeReference<>() {
+            };
+
+    @Override
+    public String convertToDatabaseColumn(List<LeaveMessageBlock> attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("leaveMessage JSON 직렬화에 실패했습니다.", e);
+        }
+    }
+
+    @Override
+    public List<LeaveMessageBlock> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return null;
+        }
+
+        String trimmed = dbData.trim();
+        if (trimmed.startsWith("[")) {
+            try {
+                List<LeaveMessageBlock> parsed = OBJECT_MAPPER.readValue(trimmed, TYPE);
+                return parsed == null ? null : new ArrayList<>(parsed);
+            } catch (JsonProcessingException e) {
+                // JSON 배열처럼 보이지만 파싱 실패 시 레거시 문자열로 취급
+                return wrapLegacy(dbData);
+            }
+        }
+
+        return wrapLegacy(dbData);
+    }
+
+    private static List<LeaveMessageBlock> wrapLegacy(String raw) {
+        List<LeaveMessageBlock> blocks = new ArrayList<>(1);
+        blocks.add(LeaveMessageBlock.builder()
+                .title("")
+                .body(raw)
+                .build());
+        return blocks;
+    }
+}

--- a/src/main/java/com/afternote/domain/afternote/service/AfternoteService.java
+++ b/src/main/java/com/afternote/domain/afternote/service/AfternoteService.java
@@ -173,7 +173,7 @@ public class AfternoteService {
                         afternote.getCategoryType(),
                         afternote.getTitle(),
                         null,
-                        null,
+                        afternote.getLeaveMessage(),
                         null,
                         receivers,
                         playlistRequest,
@@ -218,15 +218,15 @@ public class AfternoteService {
                 .user(user)
                 .categoryType(request.getCategory())
                 .title(request.getTitle())
-                .sortOrder(nextSortOrder);
-        
+                .sortOrder(nextSortOrder)
+                .leaveMessage(request.getLeaveMessage());
+
         // SOCIAL/GALLERY 전용 필드
-        if (request.getCategory() == AfternoteCategoryType.SOCIAL || 
+        if (request.getCategory() == AfternoteCategoryType.SOCIAL ||
             request.getCategory() == AfternoteCategoryType.GALLERY) {
-            builder.actions(request.getActions() != null ? new ArrayList<>(request.getActions()) : new ArrayList<>())
-                   .leaveMessage(request.getLeaveMessage());
+            builder.actions(request.getActions() != null ? new ArrayList<>(request.getActions()) : new ArrayList<>());
         }
-        
+
         Afternote afternote = builder.build();
 
         // ✅ 먼저 Afternote 저장 (ID 생성)
@@ -252,16 +252,20 @@ public class AfternoteService {
 
         // 기본 필드 업데이트 (null이 아닌 경우만)
         String title = request.getTitle() != null ? request.getTitle() : afternote.getTitle();
-        String leaveMessage = null;
-        List<String> actions = null;
-        
-        // SOCIAL/GALLERY 전용 필드 업데이트
-        if (afternote.getCategoryType() == AfternoteCategoryType.SOCIAL || 
-            afternote.getCategoryType() == AfternoteCategoryType.GALLERY) {
-            leaveMessage = request.getLeaveMessage() != null ? request.getLeaveMessage() : afternote.getLeaveMessage();
-            actions = request.getActions() != null ? request.getActions() : afternote.getActions();
+        List<LeaveMessageBlock> leaveMessage = request.getLeaveMessage() != null
+                ? request.getLeaveMessage()
+                : afternote.getLeaveMessage();
+
+        // update()가 actions를 clear 하므로 동일 리스트 참조를 넘기지 않는다
+        List<String> actions = afternote.getActions() == null
+                ? new ArrayList<>()
+                : new ArrayList<>(afternote.getActions());
+        if ((afternote.getCategoryType() == AfternoteCategoryType.SOCIAL
+                || afternote.getCategoryType() == AfternoteCategoryType.GALLERY)
+                && request.getActions() != null) {
+            actions = new ArrayList<>(request.getActions());
         }
-        
+
         afternote.update(title, afternote.getSortOrder(), leaveMessage, actions);
 
         // 관계 데이터 업데이트 (카테고리 전략 + 공통 receivers 처리)

--- a/src/main/java/com/afternote/domain/afternote/service/AfternoteValidator.java
+++ b/src/main/java/com/afternote/domain/afternote/service/AfternoteValidator.java
@@ -3,6 +3,7 @@ package com.afternote.domain.afternote.service;
 import com.afternote.domain.afternote.dto.AfternoteCreateRequest;
 import com.afternote.domain.afternote.model.AfternoteCategoryType;
 import com.afternote.domain.afternote.service.validation.AfternoteCategoryValidationStrategy;
+import com.afternote.domain.afternote.service.validation.AfternoteValidationCommons;
 import com.afternote.domain.afternote.service.validation.AfternoteValidationStrategyFactory;
 import com.afternote.global.exception.CustomException;
 import com.afternote.global.exception.ErrorCode;
@@ -29,6 +30,7 @@ public class AfternoteValidator {
             throw new CustomException(ErrorCode.CATEGORY_REQUIRED);
         }
 
+        AfternoteValidationCommons.validateLeaveMessage(request.getLeaveMessage());
         AfternoteCategoryValidationStrategy strategy = validationStrategyFactory.get(request.getCategory());
         strategy.validateCreate(request);
     }
@@ -44,6 +46,7 @@ public class AfternoteValidator {
             throw new CustomException(ErrorCode.CATEGORY_CANNOT_BE_CHANGED);
         }
 
+        AfternoteValidationCommons.validateLeaveMessage(request.getLeaveMessage());
         AfternoteCategoryValidationStrategy strategy = validationStrategyFactory.get(category);
         strategy.validateUpdate(request);
     }

--- a/src/main/java/com/afternote/domain/afternote/service/validation/AfternoteValidationCommons.java
+++ b/src/main/java/com/afternote/domain/afternote/service/validation/AfternoteValidationCommons.java
@@ -1,12 +1,17 @@
 package com.afternote.domain.afternote.service.validation;
 
 import com.afternote.domain.afternote.dto.AfternoteCreateRequest;
+import com.afternote.domain.afternote.dto.LeaveMessageBlock;
 import com.afternote.global.exception.CustomException;
 import com.afternote.global.exception.ErrorCode;
 
 import java.util.List;
 
 public final class AfternoteValidationCommons {
+
+    private static final int MAX_LEAVE_MESSAGE_BLOCKS = 20;
+    private static final int MAX_TITLE_LENGTH = 100;
+    private static final int MAX_BODY_LENGTH = 2000;
 
     private AfternoteValidationCommons() {
     }
@@ -25,6 +30,31 @@ public final class AfternoteValidationCommons {
             return;
         }
         validateReceiverIds(receivers);
+    }
+
+    public static void validateLeaveMessage(List<LeaveMessageBlock> leaveMessage) {
+        if (leaveMessage == null || leaveMessage.isEmpty()) {
+            return;
+        }
+        if (leaveMessage.size() > MAX_LEAVE_MESSAGE_BLOCKS) {
+            throw new CustomException(ErrorCode.LEAVE_MESSAGE_TOO_MANY);
+        }
+        for (LeaveMessageBlock block : leaveMessage) {
+            if (block == null) {
+                throw new CustomException(ErrorCode.LEAVE_MESSAGE_BODY_REQUIRED);
+            }
+            String body = block.getBody();
+            if (body == null || body.isBlank()) {
+                throw new CustomException(ErrorCode.LEAVE_MESSAGE_BODY_REQUIRED);
+            }
+            if (body.length() > MAX_BODY_LENGTH) {
+                throw new CustomException(ErrorCode.LEAVE_MESSAGE_BODY_TOO_LONG);
+            }
+            String title = block.getTitle();
+            if (title != null && title.length() > MAX_TITLE_LENGTH) {
+                throw new CustomException(ErrorCode.LEAVE_MESSAGE_TITLE_TOO_LONG);
+            }
+        }
     }
 
     private static void validateReceiverIds(List<AfternoteCreateRequest.ReceiverRequest> receivers) {

--- a/src/main/java/com/afternote/domain/afternote/service/validation/PlaylistValidationStrategy.java
+++ b/src/main/java/com/afternote/domain/afternote/service/validation/PlaylistValidationStrategy.java
@@ -22,9 +22,6 @@ public class PlaylistValidationStrategy implements AfternoteCategoryValidationSt
         if (request.getActions() != null) {
             throw new CustomException(ErrorCode.INVALID_FIELD_FOR_PLAYLIST);
         }
-        if (request.getLeaveMessage() != null) {
-            throw new CustomException(ErrorCode.INVALID_FIELD_FOR_PLAYLIST);
-        }
 
         if (request.getPlaylist() == null) {
             throw new CustomException(ErrorCode.PLAYLIST_REQUIRED);
@@ -50,9 +47,6 @@ public class PlaylistValidationStrategy implements AfternoteCategoryValidationSt
             throw new CustomException(ErrorCode.INVALID_FIELD_FOR_PLAYLIST);
         }
         if (request.getActions() != null) {
-            throw new CustomException(ErrorCode.INVALID_FIELD_FOR_PLAYLIST);
-        }
-        if (request.getLeaveMessage() != null) {
             throw new CustomException(ErrorCode.INVALID_FIELD_FOR_PLAYLIST);
         }
 

--- a/src/main/java/com/afternote/domain/receiver/dto/ReceivedAfternoteDetailResponse.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/ReceivedAfternoteDetailResponse.java
@@ -1,5 +1,6 @@
 package com.afternote.domain.receiver.dto;
 
+import com.afternote.domain.afternote.dto.LeaveMessageBlock;
 import com.afternote.domain.afternote.model.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -28,9 +29,9 @@ public record ReceivedAfternoteDetailResponse(
         @Getter
         List<String> actions,
 
-        @Schema(description = "남기는 메시지")
+        @Schema(description = "남기실 말씀 블록 목록 (제목+본문)")
         @Getter
-        String leaveMessage,
+        List<LeaveMessageBlock> leaveMessage,
 
         @Schema(description = "발신자 이름", example = "김철수")
         @Getter
@@ -164,6 +165,7 @@ public record ReceivedAfternoteDetailResponse(
                 .id(afternote.getId())
                 .category(afternote.getCategoryType())
                 .title(afternote.getTitle())
+                .leaveMessage(afternote.getLeaveMessage())
                 .senderName(senderName)
                 .createdAt(afternote.getCreatedAt())
                 .playlist(playlistInfo)

--- a/src/main/java/com/afternote/domain/receiver/dto/ReceivedAfternoteResponse.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/ReceivedAfternoteResponse.java
@@ -1,5 +1,6 @@
 package com.afternote.domain.receiver.dto;
 
+import com.afternote.domain.afternote.dto.LeaveMessageBlock;
 import com.afternote.domain.afternote.model.Afternote;
 import com.afternote.domain.afternote.model.AfternoteCategoryType;
 import com.afternote.domain.afternote.model.AfternoteReceiver;
@@ -8,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Schema(description = "수신한 애프터노트 응답")
 @Builder
@@ -24,9 +26,9 @@ public record ReceivedAfternoteResponse(
         @Getter
         AfternoteCategoryType category,
 
-        @Schema(description = "남기는 메시지")
+        @Schema(description = "남기실 말씀 블록 목록 (제목+본문)")
         @Getter
-        String leaveMessage,
+        List<LeaveMessageBlock> leaveMessage,
 
         @Schema(description = "발신자 ID", example = "1")
         @Getter

--- a/src/main/java/com/afternote/global/exception/ErrorCode.java
+++ b/src/main/java/com/afternote/global/exception/ErrorCode.java
@@ -146,7 +146,11 @@ public enum ErrorCode {
     FIELD_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 1619, "필드 값은 공백일 수 없습니다."),                                                                                                                    
     ATMOSPHERE_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 1620, "분위기(atmosphere)는 공백일 수 없습니다."),                                                                                                    
     VIDEO_URL_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 1621, "비디오 URL은 공백일 수 없습니다."),                                                                                                             
-    THUMBNAIL_URL_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 1622, "썸네일 URL은 공백일 수 없습니다."),                                                                                                         
+    THUMBNAIL_URL_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 1622, "썸네일 URL은 공백일 수 없습니다."),
+    LEAVE_MESSAGE_TOO_MANY(HttpStatus.BAD_REQUEST, 1623, "남기실 말씀은 최대 20개까지 등록할 수 있습니다."),
+    LEAVE_MESSAGE_BODY_REQUIRED(HttpStatus.BAD_REQUEST, 1624, "남기실 말씀 본문은 필수입니다."),
+    LEAVE_MESSAGE_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, 1625, "남기실 말씀 제목은 100자를 초과할 수 없습니다."),
+    LEAVE_MESSAGE_BODY_TOO_LONG(HttpStatus.BAD_REQUEST, 1626, "남기실 말씀 본문은 2000자를 초과할 수 없습니다."),
 
     // ======================================                                                                                                                                                               
     // 7. 암호화 관련 오류 (code: 1700 ~ 1799)                                                                                                                                                                    

--- a/src/test/java/com/afternote/domain/afternote/model/LeaveMessageListConverterTest.java
+++ b/src/test/java/com/afternote/domain/afternote/model/LeaveMessageListConverterTest.java
@@ -1,0 +1,49 @@
+package com.afternote.domain.afternote.model;
+
+import com.afternote.domain.afternote.dto.LeaveMessageBlock;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LeaveMessageListConverterTest {
+
+    private final LeaveMessageListConverter converter = new LeaveMessageListConverter();
+
+    @Test
+    @DisplayName("JSON 배열 round-trip")
+    void jsonRoundTrip() {
+        List<LeaveMessageBlock> blocks = List.of(
+                LeaveMessageBlock.builder().title("남긴말1").body("본문1").build(),
+                LeaveMessageBlock.builder().title("남긴말2").body("본문2").build()
+        );
+
+        String db = converter.convertToDatabaseColumn(blocks);
+        List<LeaveMessageBlock> restored = converter.convertToEntityAttribute(db);
+
+        assertThat(db).startsWith("[");
+        assertThat(restored).hasSize(2);
+        assertThat(restored.get(0).getTitle()).isEqualTo("남긴말1");
+        assertThat(restored.get(1).getBody()).isEqualTo("본문2");
+    }
+
+    @Test
+    @DisplayName("레거시 plain string 은 단일 블록으로 wrap")
+    void legacyString_WrapsAsSingleBlock() {
+        List<LeaveMessageBlock> restored = converter.convertToEntityAttribute("예전 단일 문자열");
+
+        assertThat(restored).hasSize(1);
+        assertThat(restored.get(0).getTitle()).isEqualTo("");
+        assertThat(restored.get(0).getBody()).isEqualTo("예전 단일 문자열");
+    }
+
+    @Test
+    @DisplayName("null/blank 은 null")
+    void nullAndBlank() {
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+        assertThat(converter.convertToEntityAttribute("  ")).isNull();
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+    }
+}

--- a/src/test/java/com/afternote/domain/afternote/service/AfternoteServiceTest.java
+++ b/src/test/java/com/afternote/domain/afternote/service/AfternoteServiceTest.java
@@ -3,6 +3,7 @@ package com.afternote.domain.afternote.service;
 import com.afternote.domain.afternote.dto.AfternoteCreateRequest;
 import com.afternote.domain.afternote.dto.AfternoteCreateResponse;
 import com.afternote.domain.afternote.dto.AfternotePageResponse;
+import com.afternote.domain.afternote.dto.LeaveMessageBlock;
 import com.afternote.domain.afternote.model.Afternote;
 import com.afternote.domain.afternote.model.AfternoteCategoryType;
 import com.afternote.domain.afternote.repository.AfternoteRepository;
@@ -91,7 +92,9 @@ class AfternoteServiceTest {
         given(request.getCategory()).willReturn(AfternoteCategoryType.SOCIAL);
         given(request.getTitle()).willReturn("social");
         given(request.getActions()).willReturn(List.of("action1"));
-        given(request.getLeaveMessage()).willReturn("message");
+        given(request.getLeaveMessage()).willReturn(List.of(
+                LeaveMessageBlock.builder().title("t1").body("message").build()
+        ));
 
         User user = sampleUser(1L);
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
@@ -109,8 +112,38 @@ class AfternoteServiceTest {
         ArgumentCaptor<Afternote> captor = ArgumentCaptor.forClass(Afternote.class);
         verify(afternoteRepository).save(captor.capture());
         assertThat(captor.getValue().getSortOrder()).isEqualTo(3);
+        assertThat(captor.getValue().getLeaveMessage()).hasSize(1);
+        assertThat(captor.getValue().getLeaveMessage().get(0).getBody()).isEqualTo("message");
         verify(validator).validateCreateRequest(request);
         verify(relationService).saveRelationsByCategory(any(Afternote.class), eq(request));
+    }
+
+    @Test
+    @DisplayName("PLAYLIST 생성 시 leaveMessage 저장")
+    void createAfternote_Playlist_LeaveMessage_Saved() {
+        AfternoteCreateRequest request = org.mockito.Mockito.mock(AfternoteCreateRequest.class);
+        given(request.getCategory()).willReturn(AfternoteCategoryType.PLAYLIST);
+        given(request.getTitle()).willReturn("playlist");
+        given(request.getLeaveMessage()).willReturn(List.of(
+                LeaveMessageBlock.builder().title("남긴말").body("본문").build()
+        ));
+
+        User user = sampleUser(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(afternoteRepository.findMaxSortOrderByUserId(1L)).willReturn(Optional.of(0));
+        given(afternoteRepository.save(any(Afternote.class))).willAnswer(invocation -> {
+            Afternote saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 101L);
+            return saved;
+        });
+
+        afternoteService.createAfternote(1L, request);
+
+        ArgumentCaptor<Afternote> captor = ArgumentCaptor.forClass(Afternote.class);
+        verify(afternoteRepository).save(captor.capture());
+        assertThat(captor.getValue().getLeaveMessage()).hasSize(1);
+        assertThat(captor.getValue().getLeaveMessage().get(0).getTitle()).isEqualTo("남긴말");
+        assertThat(captor.getValue().getActions()).isNullOrEmpty();
     }
 
     @Test
@@ -152,14 +185,18 @@ class AfternoteServiceTest {
                 .categoryType(AfternoteCategoryType.SOCIAL)
                 .title("before")
                 .sortOrder(1)
-                .leaveMessage("before-message")
+                .leaveMessage(new ArrayList<>(List.of(
+                        LeaveMessageBlock.builder().title("").body("before-message").build()
+                )))
             .actions(new ArrayList<>(List.of("a1")))
                 .build();
         ReflectionTestUtils.setField(afternote, "id", 10L);
 
         AfternoteCreateRequest request = org.mockito.Mockito.mock(AfternoteCreateRequest.class);
         given(request.getTitle()).willReturn("after");
-        given(request.getLeaveMessage()).willReturn("after-message");
+        given(request.getLeaveMessage()).willReturn(List.of(
+                LeaveMessageBlock.builder().title("t").body("after-message").build()
+        ));
         given(request.getActions()).willReturn(List.of("a2", "a3"));
 
         given(afternoteRepository.findById(10L)).willReturn(Optional.of(afternote));
@@ -168,7 +205,8 @@ class AfternoteServiceTest {
 
         assertThat(response.getAfternoteId()).isEqualTo(10L);
         assertThat(afternote.getTitle()).isEqualTo("after");
-        assertThat(afternote.getLeaveMessage()).isEqualTo("after-message");
+        assertThat(afternote.getLeaveMessage()).hasSize(1);
+        assertThat(afternote.getLeaveMessage().get(0).getBody()).isEqualTo("after-message");
         assertThat(afternote.getActions()).containsExactly("a2", "a3");
         verify(validator).validateUpdateRequest(request, AfternoteCategoryType.SOCIAL);
         verify(relationService).updateRelationsByCategory(afternote, request, AfternoteCategoryType.SOCIAL);

--- a/src/test/java/com/afternote/domain/afternote/service/validation/AfternoteValidationCommonsTest.java
+++ b/src/test/java/com/afternote/domain/afternote/service/validation/AfternoteValidationCommonsTest.java
@@ -1,0 +1,59 @@
+package com.afternote.domain.afternote.service.validation;
+
+import com.afternote.domain.afternote.dto.LeaveMessageBlock;
+import com.afternote.global.exception.CustomException;
+import com.afternote.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AfternoteValidationCommonsTest {
+
+    @Test
+    @DisplayName("leaveMessage null/empty 허용")
+    void leaveMessage_NullOrEmpty_Ok() {
+        assertThatCode(() -> AfternoteValidationCommons.validateLeaveMessage(null))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> AfternoteValidationCommons.validateLeaveMessage(List.of()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("body blank 이면 실패")
+    void leaveMessage_BlankBody_Fail() {
+        assertThatThrownBy(() -> AfternoteValidationCommons.validateLeaveMessage(List.of(
+                LeaveMessageBlock.builder().title("t").body("  ").build()
+        )))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.LEAVE_MESSAGE_BODY_REQUIRED));
+    }
+
+    @Test
+    @DisplayName("블록 21개 초과 실패")
+    void leaveMessage_TooMany_Fail() {
+        List<LeaveMessageBlock> blocks = new ArrayList<>();
+        for (int i = 0; i < 21; i++) {
+            blocks.add(LeaveMessageBlock.builder().title("t" + i).body("body" + i).build());
+        }
+
+        assertThatThrownBy(() -> AfternoteValidationCommons.validateLeaveMessage(blocks))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.LEAVE_MESSAGE_TOO_MANY));
+    }
+
+    @Test
+    @DisplayName("title 없이도 body 있으면 성공")
+    void leaveMessage_OptionalTitle_Ok() {
+        assertThatCode(() -> AfternoteValidationCommons.validateLeaveMessage(List.of(
+                LeaveMessageBlock.builder().title(null).body("본문만").build()
+        ))).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Summary
- `leaveMessage` 계약을 `String` → `{title, body}[]` 로 변경 (생성/작성자 상세/수신 목록·상세)
- DB는 기존 `leave_message` TEXT 컬럼에 JSON 배열 문자열로 저장 (스키마 마이그레이션 없음)
- 레거시 plain string은 읽기 시 `[{title:\"\", body:원문}]` 으로 wrap
- SOCIAL/GALLERY/PLAYLIST 전부 `leaveMessage` 저장·노출 (`actions`는 기존처럼 SOCIAL/GALLERY만)
- Playlist validation의 leaveMessage reject 제거 → #104(PLAYLIST 저장 누락)도 해소
- 검증: body 필수, title 선택, 최대 20블록, title≤100 / body≤2000

## Test plan
- [ ] `POST /afternotes` 에 `leaveMessage: [{title, body}]` 저장 후 상세에서 배열로 조회
- [ ] PLAYLIST 생성/수정에도 leaveMessage 반영되는지 확인
- [ ] 기존 plain string 데이터가 상세에서 단일 블록으로 보이는지 확인
- [ ] body 빈 값 / 21개 초과 시 400
- [ ] FE #510 과 배포 순서 맞추기 (breaking change)

Closes #78
Related #104


Made with [Cursor](https://cursor.com)