### PR TITLE
fix: 애프터노트 상세 receivers에 name·relation 포함 (#81)

### DIFF
--- a/src/main/java/com/afternote/domain/afternote/dto/AfternoteReceiverResponse.java
+++ b/src/main/java/com/afternote/domain/afternote/dto/AfternoteReceiverResponse.java
@@ -1,0 +1,31 @@
+package com.afternote.domain.afternote.dto;
+
+import com.afternote.domain.receiver.model.Receiver;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Schema(description = "애프터노트 수신자 요약")
+public record AfternoteReceiverResponse(
+        @Schema(description = "수신자 ID", example = "1")
+        @Getter
+        Long receiverId,
+
+        @Schema(description = "수신자 이름", example = "김소희")
+        @Getter
+        String name,
+
+        @Schema(description = "수신인과의 관계", example = "딸")
+        @Getter
+        String relation
+) {
+
+    public static AfternoteReceiverResponse from(Receiver receiver) {
+        return AfternoteReceiverResponse.builder()
+                .receiverId(receiver.getId())
+                .name(receiver.getName())
+                .relation(receiver.getRelation())
+                .build();
+    }
+}

--- a/src/main/java/com/afternote/domain/afternote/dto/AfternotedetailResponse.java
+++ b/src/main/java/com/afternote/domain/afternote/dto/AfternotedetailResponse.java
@@ -32,9 +32,9 @@ public record AfternotedetailResponse(
         @Getter
         AfternoteCreateRequest.CredentialsRequest credentials,
 
-        @Schema(description = "수신자 목록")
+        @Schema(description = "수신자 목록 (receiverId, name, relation)")
         @Getter
-        List<AfternoteCreateRequest.ReceiverRequest> receivers,
+        List<AfternoteReceiverResponse> receivers,
 
         @Schema(description = "플레이리스트 정보 (Playlist 전용)")
         @Getter

--- a/src/main/java/com/afternote/domain/afternote/service/AfternoteService.java
+++ b/src/main/java/com/afternote/domain/afternote/service/AfternoteService.java
@@ -74,8 +74,8 @@ public class AfternoteService {
         }
         
         // 모든 카테고리에서 공통으로 필요한 receivers 매핑
-        List<AfternoteCreateRequest.ReceiverRequest> receivers = afternote.getReceivers().stream()
-                .map(ar -> new AfternoteCreateRequest.ReceiverRequest(ar.getReceiver().getId()))
+        List<AfternoteReceiverResponse> receivers = afternote.getReceivers().stream()
+                .map(ar -> AfternoteReceiverResponse.from(ar.getReceiver()))
                 .collect(Collectors.toList());
         
         AfternotedetailResponse response;

--- a/src/test/java/com/afternote/domain/afternote/service/AfternoteServiceTest.java
+++ b/src/test/java/com/afternote/domain/afternote/service/AfternoteServiceTest.java
@@ -3,11 +3,14 @@ package com.afternote.domain.afternote.service;
 import com.afternote.domain.afternote.dto.AfternoteCreateRequest;
 import com.afternote.domain.afternote.dto.AfternoteCreateResponse;
 import com.afternote.domain.afternote.dto.AfternotePageResponse;
+import com.afternote.domain.afternote.dto.AfternotedetailResponse;
 import com.afternote.domain.afternote.dto.LeaveMessageBlock;
 import com.afternote.domain.afternote.model.Afternote;
 import com.afternote.domain.afternote.model.AfternoteCategoryType;
+import com.afternote.domain.afternote.model.AfternoteReceiver;
 import com.afternote.domain.afternote.repository.AfternoteRepository;
 import com.afternote.domain.image.service.S3Service;
+import com.afternote.domain.receiver.model.Receiver;
 import com.afternote.domain.user.model.AuthProvider;
 import com.afternote.domain.user.model.User;
 import com.afternote.domain.user.model.UserStatus;
@@ -210,6 +213,44 @@ class AfternoteServiceTest {
         assertThat(afternote.getActions()).containsExactly("a2", "a3");
         verify(validator).validateUpdateRequest(request, AfternoteCategoryType.SOCIAL);
         verify(relationService).updateRelationsByCategory(afternote, request, AfternoteCategoryType.SOCIAL);
+    }
+
+    @Test
+    @DisplayName("애프터노트 상세 조회 - receivers 에 name·relation 포함")
+    void getDetailAfternote_ReceiversIncludeNameAndRelation() {
+        User owner = sampleUser(1L);
+        Afternote afternote = Afternote.builder()
+                .user(owner)
+                .categoryType(AfternoteCategoryType.GALLERY)
+                .title("구글 포토")
+                .sortOrder(1)
+                .actions(new ArrayList<>(List.of("QA runtime check")))
+                .build();
+        ReflectionTestUtils.setField(afternote, "id", 1L);
+
+        Receiver receiver = Receiver.builder()
+                .name("김소희")
+                .relation("딸")
+                .phone("010")
+                .email("a@a.com")
+                .userId(1L)
+                .build();
+        ReflectionTestUtils.setField(receiver, "id", 1L);
+
+        AfternoteReceiver link = AfternoteReceiver.builder()
+                .afternote(afternote)
+                .receiver(receiver)
+                .build();
+        afternote.getReceivers().add(link);
+
+        given(afternoteRepository.findById(1L)).willReturn(Optional.of(afternote));
+
+        AfternotedetailResponse response = afternoteService.getDetailAfternote(1L, 1L);
+
+        assertThat(response.getReceivers()).hasSize(1);
+        assertThat(response.getReceivers().get(0).getReceiverId()).isEqualTo(1L);
+        assertThat(response.getReceivers().get(0).getName()).isEqualTo("김소희");
+        assertThat(response.getReceivers().get(0).getRelation()).isEqualTo("딸");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `GET /api/v1/afternotes/{afternoteId}` 응답 `receivers`에 `name`, `relation` 추가
- 요청 DTO(`ReceiverRequest`)는 `receiverId`만 유지하고, 상세 응답은 `AfternoteReceiverResponse`로 분리

## Test plan
- [ ] `GET /api/v1/afternotes/{id}` 응답이 `receivers: [{receiverId, name, relation}]` 형태인지 확인
- [ ] 앱 상세 수신자 카드에 이름·관계가 표시되는지 확인
- [ ] 생성/수정 요청 바디의 `receivers`는 기존처럼 `receiverId`만으로도 동작하는지 확인

Closes #81


Made with [Cursor](https://cursor.com)