### PR TITLE
fix: 수신자 등록 전화번호 형식·중복 검증 (#86)

### DIFF
--- a/src/main/java/com/afternote/domain/receiver/repository/ReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/ReceiverRepository.java
@@ -11,4 +11,5 @@ import java.util.Optional;
 public interface ReceiverRepository extends JpaRepository<Receiver, Long> {
     Optional<Receiver> findByAuthCode(String authCode);
     List<Receiver> findAllByEmailIgnoreCaseOrderByIdDesc(String email);
+    List<Receiver> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/afternote/domain/user/dto/UserCreateReceiverRequest.java
+++ b/src/main/java/com/afternote/domain/user/dto/UserCreateReceiverRequest.java
@@ -15,7 +15,7 @@ public record UserCreateReceiverRequest(
         @Getter
         String relation,
 
-        @Schema(description = "전화번호", example = "010-1234-1234", nullable = true)
+        @Schema(description = "전화번호 (선택, 입력 시 국내 휴대폰 형식)", example = "010-1234-5678", nullable = true)
         @Getter
         String phone,
 

--- a/src/main/java/com/afternote/domain/user/service/UserService.java
+++ b/src/main/java/com/afternote/domain/user/service/UserService.java
@@ -17,12 +17,14 @@ import com.afternote.domain.user.repository.UserRepository;
 import com.afternote.domain.receiver.service.AuthCodeMessageService;
 import com.afternote.global.exception.CustomException;
 import com.afternote.global.exception.ErrorCode;
+import com.afternote.global.util.PhoneNumbers;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Slf4j
@@ -193,6 +195,9 @@ public class UserService {
     ) {
         User user = findUserById(userId);
 
+        PhoneNumbers.validateOptional(request.getPhone());
+        ensureUniqueReceiverPhone(user.getId(), request.getPhone(), null);
+
         Receiver receiver = Receiver.builder()
                 .name(request.getName())
                 .relation(request.getRelation())
@@ -296,6 +301,9 @@ public class UserService {
 
         Receiver receiver = userReceiver.getReceiver();
 
+        PhoneNumbers.validateRequired(request.getPhone());
+        ensureUniqueReceiverPhone(user.getId(), request.getPhone(), receiver.getId());
+
         receiver.updateInfo(
                 request.getName(),
                 request.getRelation(),
@@ -306,5 +314,23 @@ public class UserService {
         return UserPatchReceiverResponse.from(receiver);
     }
 
+    /**
+     * 같은 사용자의 동일 전화번호(하이픈/공백 무시) 중복 등록은 거부한다.
+     */
+    private void ensureUniqueReceiverPhone(Long userId, String phone, Long excludeReceiverId) {
+        if (PhoneNumbers.isBlank(phone)) {
+            return;
+        }
+        String normalized = PhoneNumbers.normalize(phone);
+        boolean duplicated = receiverRepository.findAllByUserId(userId).stream()
+                .filter(r -> excludeReceiverId == null || !Objects.equals(r.getId(), excludeReceiverId))
+                .map(Receiver::getPhone)
+                .filter(p -> !PhoneNumbers.isBlank(p))
+                .map(PhoneNumbers::normalize)
+                .anyMatch(normalized::equals);
+        if (duplicated) {
+            throw new CustomException(ErrorCode.DUPLICATE_RECEIVER_PHONE);
+        }
+    }
 
 }

--- a/src/main/java/com/afternote/global/exception/ErrorCode.java
+++ b/src/main/java/com/afternote/global/exception/ErrorCode.java
@@ -151,6 +151,8 @@ public enum ErrorCode {
     LEAVE_MESSAGE_BODY_REQUIRED(HttpStatus.BAD_REQUEST, 1624, "남기실 말씀 본문은 필수입니다."),
     LEAVE_MESSAGE_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, 1625, "남기실 말씀 제목은 100자를 초과할 수 없습니다."),
     LEAVE_MESSAGE_BODY_TOO_LONG(HttpStatus.BAD_REQUEST, 1626, "남기실 말씀 본문은 2000자를 초과할 수 없습니다."),
+    INVALID_PHONE_FORMAT(HttpStatus.BAD_REQUEST, 1627, "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)"),
+    DUPLICATE_RECEIVER_PHONE(HttpStatus.CONFLICT, 1628, "이미 등록된 수신자 전화번호입니다."),
 
     // ======================================                                                                                                                                                               
     // 7. 암호화 관련 오류 (code: 1700 ~ 1799)                                                                                                                                                                    

--- a/src/main/java/com/afternote/global/util/PhoneNumbers.java
+++ b/src/main/java/com/afternote/global/util/PhoneNumbers.java
@@ -1,0 +1,45 @@
+package com.afternote.global.util;
+
+import com.afternote.global.exception.CustomException;
+import com.afternote.global.exception.ErrorCode;
+
+import java.util.regex.Pattern;
+
+/**
+ * 수신자/연락처용 국내 휴대폰 번호 유틸.
+ * 허용: 01012345678, 010-1234-5678, 010 1234 5678 등 (숫자 10~11자리, 01X 시작)
+ */
+public final class PhoneNumbers {
+
+    private static final Pattern MOBILE_DIGITS = Pattern.compile("^01[016789]\\d{7,8}$");
+
+    private PhoneNumbers() {
+    }
+
+    public static String normalize(String phone) {
+        if (phone == null) {
+            return null;
+        }
+        return phone.replaceAll("[^0-9]", "");
+    }
+
+    public static boolean isBlank(String phone) {
+        return phone == null || phone.isBlank();
+    }
+
+    /**
+     * phone 이 비어 있으면 통과(선택 필드). 값이 있으면 형식 검증.
+     */
+    public static void validateOptional(String phone) {
+        if (isBlank(phone)) {
+            return;
+        }
+        validateRequired(phone);
+    }
+
+    public static void validateRequired(String phone) {
+        if (isBlank(phone) || !MOBILE_DIGITS.matcher(normalize(phone)).matches()) {
+            throw new CustomException(ErrorCode.INVALID_PHONE_FORMAT);
+        }
+    }
+}

--- a/src/test/java/com/afternote/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/afternote/domain/user/controller/UserControllerTest.java
@@ -133,7 +133,7 @@ class UserControllerTest {
         mockMvc.perform(post("/api/v1/users/receivers")
                         .requestAttr(UserIdArgumentResolver.USER_ID_ATTRIBUTE, USER_ID)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"kim\",\"relation\":\"DAUGHTER\",\"phone\":\"010\",\"email\":\"a@a.com\"}"))
+                        .content("{\"name\":\"kim\",\"relation\":\"DAUGHTER\",\"phone\":\"010-1234-5678\",\"email\":\"a@a.com\"}"))
                 .andExpect(status().isOk());
 
         verify(userService).createReceiver(eq(USER_ID), any());

--- a/src/test/java/com/afternote/domain/user/service/UserServiceCreateReceiverTest.java
+++ b/src/test/java/com/afternote/domain/user/service/UserServiceCreateReceiverTest.java
@@ -1,0 +1,139 @@
+package com.afternote.domain.user.service;
+
+import com.afternote.domain.auth.service.TokenService;
+import com.afternote.domain.auth.service.social.SocialLoginFactory;
+import com.afternote.domain.image.service.S3Service;
+import com.afternote.domain.receiver.model.Receiver;
+import com.afternote.domain.receiver.repository.ReceiverRepository;
+import com.afternote.domain.receiver.repository.UserReceiverRepository;
+import com.afternote.domain.receiver.service.AuthCodeMessageService;
+import com.afternote.domain.receiver.service.DeliveryVerificationService;
+import com.afternote.domain.user.dto.UserCreateReceiverRequest;
+import com.afternote.domain.user.model.AuthProvider;
+import com.afternote.domain.user.model.User;
+import com.afternote.domain.user.model.UserStatus;
+import com.afternote.domain.user.repository.UserProviderRepository;
+import com.afternote.domain.user.repository.UserRepository;
+import com.afternote.global.exception.CustomException;
+import com.afternote.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceCreateReceiverTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private UserReceiverRepository userReceiverRepository;
+    @Mock
+    private ReceiverRepository receiverRepository;
+    @Mock
+    private AuthCodeMessageService authCodeMessageService;
+    @Mock
+    private S3Service s3Service;
+    @Mock
+    private DeliveryVerificationService deliveryVerificationService;
+    @Mock
+    private TokenService tokenService;
+    @Mock
+    private SocialLoginFactory socialLoginFactory;
+    @Mock
+    private UserProviderRepository userProviderRepository;
+
+    @Test
+    @DisplayName("수신자 등록 실패 - 전화번호 형식")
+    void createReceiver_InvalidPhone_Fail() {
+        User user = sampleUser(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        UserCreateReceiverRequest request = new UserCreateReceiverRequest(
+                "Invalid Phone", "아들", "abc123", "a@a.com", null
+        );
+
+        assertThatThrownBy(() -> userService.createReceiver(1L, request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_PHONE_FORMAT));
+        verify(receiverRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("수신자 등록 실패 - 동일 전화번호 중복")
+    void createReceiver_DuplicatePhone_Fail() {
+        User user = sampleUser(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        Receiver existing = Receiver.builder()
+                .name("기존")
+                .relation("아들")
+                .phone("010-1234-5678")
+                .userId(1L)
+                .build();
+        ReflectionTestUtils.setField(existing, "id", 12L);
+        given(receiverRepository.findAllByUserId(1L)).willReturn(List.of(existing));
+
+        UserCreateReceiverRequest request = new UserCreateReceiverRequest(
+                "Invalid Phone Dup", "아들", "01012345678", "b@b.com", null
+        );
+
+        assertThatThrownBy(() -> userService.createReceiver(1L, request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.DUPLICATE_RECEIVER_PHONE));
+        verify(receiverRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("수신자 등록 성공 - 유효 전화번호")
+    void createReceiver_ValidPhone_Success() {
+        User user = sampleUser(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(receiverRepository.findAllByUserId(1L)).willReturn(List.of());
+        given(receiverRepository.save(any(Receiver.class))).willAnswer(invocation -> {
+            Receiver saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 100L);
+            return saved;
+        });
+        given(userReceiverRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        UserCreateReceiverRequest request = new UserCreateReceiverRequest(
+                "김지은", "딸", "010-1234-5678", "jieun@naver.com", null
+        );
+
+        var response = userService.createReceiver(1L, request);
+
+        assertThat(response.receiverId()).isEqualTo(100L);
+        verify(receiverRepository).save(any(Receiver.class));
+    }
+
+    private static User sampleUser(Long id) {
+        User user = User.builder()
+                .email("u@test.com")
+                .password("pw")
+                .name("tester")
+                .status(UserStatus.ACTIVE)
+                .provider(AuthProvider.LOCAL)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}

--- a/src/test/java/com/afternote/global/util/PhoneNumbersTest.java
+++ b/src/test/java/com/afternote/global/util/PhoneNumbersTest.java
@@ -1,0 +1,40 @@
+package com.afternote.global.util;
+
+import com.afternote.global.exception.CustomException;
+import com.afternote.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PhoneNumbersTest {
+
+    @Test
+    @DisplayName("유효한 휴대폰 형식 통과")
+    void validPhones() {
+        assertThatCode(() -> PhoneNumbers.validateOptional("010-1234-5678")).doesNotThrowAnyException();
+        assertThatCode(() -> PhoneNumbers.validateOptional("01012345678")).doesNotThrowAnyException();
+        assertThatCode(() -> PhoneNumbers.validateOptional("010 1234 5678")).doesNotThrowAnyException();
+        assertThatCode(() -> PhoneNumbers.validateOptional(null)).doesNotThrowAnyException();
+        assertThatCode(() -> PhoneNumbers.validateOptional("")).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("잘못된 형식은 INVALID_PHONE_FORMAT")
+    void invalidPhones() {
+        assertThatThrownBy(() -> PhoneNumbers.validateOptional("abc123"))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_PHONE_FORMAT));
+        assertThatThrownBy(() -> PhoneNumbers.validateOptional("1234"))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    @DisplayName("normalize 는 숫자만 남긴다")
+    void normalize() {
+        assertThat(PhoneNumbers.normalize("010-1234-5678")).isEqualTo("01012345678");
+    }
+}


### PR DESCRIPTION
## Summary
- `POST /api/v1/users/receivers` — `phone` 형식 검증 (국내 휴대폰, 하이픈/공백 허용). 불일치 시 **400 / 1627**
- 같은 사용자의 동일 `phone` 중복 등록 **거부** (하이픈 유무 무시). 중복 시 **409 / 1628**
- `PATCH /api/v1/users/receivers/{id}` 수정에도 동일 규칙 적용
- `phone` 미입력(null/blank)은 생성 시 계속 허용

## Test plan
- [ ] `phone: \"abc123\"` → 400, code 1627
- [ ] 같은 계정으로 `010-1234-5678` 등록 후 `01012345678` 재등록 → 409, code 1628
- [ ] `010-1234-5678` 정상 등록 → 200
- [ ] phone 없이 등록 → 200 (기존과 동일)

Closes #86


Made with [Cursor](https://cursor.com)