### PR TITLE
fix: 탈퇴 FK 정리·30일 재가입 제한·accessToken 무효화 (#87 #88 #89)

### DIFF
--- a/src/main/java/com/afternote/domain/afternote/repository/AfternoteRepository.java
+++ b/src/main/java/com/afternote/domain/afternote/repository/AfternoteRepository.java
@@ -9,10 +9,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface AfternoteRepository extends JpaRepository<Afternote, Long> {
+
+    @Query("SELECT a.id FROM Afternote a WHERE a.user.id = :userId")
+    List<Long> findIdsByUserId(@Param("userId") Long userId);
     
     // 전체 목록 페이징 조회
     @Query("SELECT a FROM Afternote a WHERE a.user.id = :userId ORDER BY a.createdAt DESC")

--- a/src/main/java/com/afternote/domain/auth/service/AuthService.java
+++ b/src/main/java/com/afternote/domain/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import com.afternote.domain.user.model.AuthProvider;
 import com.afternote.domain.user.model.User;
 import com.afternote.domain.user.model.UserStatus;
 import com.afternote.domain.user.repository.UserRepository;
+import com.afternote.domain.user.service.WithdrawalCooldownService;
 import com.afternote.global.exception.CustomException;
 import com.afternote.global.exception.ErrorCode;
 import com.afternote.global.jwt.JwtTokenProvider;
@@ -26,6 +27,7 @@ public class AuthService {
 
     private final TokenService tokenService;
     private final EmailService emailService;
+    private final WithdrawalCooldownService withdrawalCooldownService;
     
     // 🎯 핵심: SocialLoginFactory 주입
     private final SocialLoginFactory socialLoginFactory;
@@ -35,6 +37,7 @@ public class AuthService {
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
         }
+        withdrawalCooldownService.assertNotInCooldown(request.getEmail());
 
         if (!emailService.consumeVerified(request.getEmail(), EmailVerificationPurpose.SIGNUP)) {
             throw new CustomException(ErrorCode.EMAIL_NOT_VERIFIED);
@@ -145,6 +148,7 @@ public class AuthService {
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
         }
+        withdrawalCooldownService.assertNotInCooldown(request.getEmail());
         return EmailSendResponse.of(
                 emailService.sendCode(request.getEmail(), EmailVerificationPurpose.SIGNUP)
         );
@@ -250,6 +254,7 @@ public class AuthService {
         boolean isNewUser = false;
         
         if (user == null) {
+            withdrawalCooldownService.assertNotInCooldown(socialUserInfo.getEmail());
             user = User.builder()
                     .email(socialUserInfo.getEmail())
                     .name(socialUserInfo.getName())

--- a/src/main/java/com/afternote/domain/auth/service/TokenService.java
+++ b/src/main/java/com/afternote/domain/auth/service/TokenService.java
@@ -1,16 +1,25 @@
 package com.afternote.domain.auth.service;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+
 import java.util.concurrent.TimeUnit;
 
 @Service
 public class TokenService {
 
-    private final RedisTemplate<String, Long> redisTemplate;
+    private static final String ACCESS_REVOKED_PREFIX = "AT:REVOKED:";
 
-    public TokenService(RedisTemplate<String, Long> redisTemplate) {
+    private final RedisTemplate<String, Long> redisTemplate;
+    private final long accessTokenExpirationMs;
+
+    public TokenService(
+            RedisTemplate<String, Long> redisTemplate,
+            @Value("${jwt.access-token-expiration}") long accessTokenExpirationMs
+    ) {
         this.redisTemplate = redisTemplate;
+        this.accessTokenExpirationMs = accessTokenExpirationMs;
     }
 
     // Refresh Token 저장 (예: 7일간 유효)
@@ -48,5 +57,22 @@ public class TokenService {
                 }
             }
         }
+    }
+
+    /**
+     * 탈퇴/강제 만료 시 accessToken 을 즉시 무효화한다.
+     * TTL 은 access token 최대 수명과 동일하게 둔다.
+     */
+    public void revokeUserAccess(Long userId) {
+        redisTemplate.opsForValue().set(
+                ACCESS_REVOKED_PREFIX + userId,
+                userId,
+                accessTokenExpirationMs,
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    public boolean isAccessRevoked(Long userId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(ACCESS_REVOKED_PREFIX + userId));
     }
 }

--- a/src/main/java/com/afternote/domain/dailyquestion/repository/UserDailyQuestionRepository.java
+++ b/src/main/java/com/afternote/domain/dailyquestion/repository/UserDailyQuestionRepository.java
@@ -2,12 +2,17 @@ package com.afternote.domain.dailyquestion.repository;
 
 import com.afternote.domain.dailyquestion.model.UserDailyQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface UserDailyQuestionRepository extends JpaRepository<UserDailyQuestion, Long> {
+
+    @Query("SELECT q.id FROM UserDailyQuestion q WHERE q.user.id = :userId")
+    List<Long> findIdsByUserId(@Param("userId") Long userId);
     
     Optional<UserDailyQuestion> findByUserIdAndQuestionDate(Long userId, LocalDate questionDate);
     

--- a/src/main/java/com/afternote/domain/deepthought/repository/DeepThoughtCategoryRepository.java
+++ b/src/main/java/com/afternote/domain/deepthought/repository/DeepThoughtCategoryRepository.java
@@ -17,4 +17,6 @@ public interface DeepThoughtCategoryRepository extends JpaRepository<DeepThought
     List<DeepThoughtCategory> findByUserIdOrderByIdAsc(Long userId);
 
     boolean existsByUserIdAndTitle(Long userId, String title);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/src/main/java/com/afternote/domain/deepthought/repository/DeepThoughtRepository.java
+++ b/src/main/java/com/afternote/domain/deepthought/repository/DeepThoughtRepository.java
@@ -54,9 +54,16 @@ public interface DeepThoughtRepository extends JpaRepository<DeepThought, Long> 
 
     long countByUserId(Long userId);
 
+    @Query("SELECT dt.id FROM DeepThought dt WHERE dt.user.id = :userId")
+    List<Long> findIdsByUserId(@Param("userId") Long userId);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE DeepThought dt SET dt.category = null WHERE dt.user.id = :userId AND dt.category.id = :categoryId")
     int clearCategoryByUserIdAndCategoryId(@Param("userId") Long userId, @Param("categoryId") Long categoryId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE DeepThought dt SET dt.category = null WHERE dt.user.id = :userId")
+    int clearCategoryByUserId(@Param("userId") Long userId);
 
     @Query(value = "SELECT * FROM deep_thought dt WHERE dt.user_id = :userId LIMIT 1 OFFSET :offset", nativeQuery = true)
     Optional<DeepThought> findByUserIdWithOffset(@Param("userId") Long userId, @Param("offset") int offset);

--- a/src/main/java/com/afternote/domain/delivery/repository/DeliveryConditionRepository.java
+++ b/src/main/java/com/afternote/domain/delivery/repository/DeliveryConditionRepository.java
@@ -22,4 +22,6 @@ public interface DeliveryConditionRepository extends JpaRepository<DeliveryCondi
             DeliveryConditionType conditionType, ConditionState state);
 
     boolean existsByReceiverIdAndState(Long receiverId, ConditionState state);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/afternote/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/afternote/domain/diary/repository/DiaryRepository.java
@@ -14,6 +14,9 @@ import java.util.Optional;
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
+	@Query("SELECT d.id FROM Diary d WHERE d.user.id = :userId")
+	List<Long> findIdsByUserId(@Param("userId") Long userId);
+
 	Optional<Diary> findByIdAndUserId(Long diaryId, Long userId);
 
 	List<Diary> findByUserIdAndCreatedAtBetweenOrderByCreatedAtDesc(

--- a/src/main/java/com/afternote/domain/mindrecord/emotion/repository/EmotionRepository.java
+++ b/src/main/java/com/afternote/domain/mindrecord/emotion/repository/EmotionRepository.java
@@ -19,4 +19,6 @@ public interface EmotionRepository extends JpaRepository<Emotion, Long> {
     Optional<Emotion> findByUserIdAndSourceTypeAndSourceId(Long userId, EmotionSourceType sourceType, Long sourceId);
 
     List<Emotion> findByUserIdAndSourceTypeAndSourceIdIn(Long userId, EmotionSourceType sourceType, List<Long> sourceIds);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/src/main/java/com/afternote/domain/mindrecord/weekly/repository/WeeklyReportRepository.java
+++ b/src/main/java/com/afternote/domain/mindrecord/weekly/repository/WeeklyReportRepository.java
@@ -14,4 +14,6 @@ public interface WeeklyReportRepository extends JpaRepository<WeeklyReport, Long
     List<WeeklyReport> findByUserIdOrderByEndDateDesc(Long userId);
 
     Optional<WeeklyReport> findByUserIdAndStartDate(Long userId, LocalDateTime startDate);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/AfternoteReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/AfternoteReceiverRepository.java
@@ -2,6 +2,7 @@ package com.afternote.domain.receiver.repository;
 
 import com.afternote.domain.afternote.model.AfternoteReceiver;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -30,4 +31,8 @@ public interface AfternoteReceiverRepository extends JpaRepository<AfternoteRece
             @Param("receiverId") Long receiverId);
 
     boolean existsByReceiverId(Long receiverId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM AfternoteReceiver ar WHERE ar.afternote.id IN :afternoteIds")
+    void deleteByAfternoteIdIn(@Param("afternoteIds") List<Long> afternoteIds);
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/DeepThoughtReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/DeepThoughtReceiverRepository.java
@@ -3,6 +3,7 @@ package com.afternote.domain.receiver.repository;
 import com.afternote.domain.deepthought.dto.DeepThoughtTagCountResponse;
 import com.afternote.domain.receiver.model.DeepThoughtReceiver;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -23,6 +24,10 @@ public interface DeepThoughtReceiverRepository extends JpaRepository<DeepThought
     List<DeepThoughtReceiver> findByDeepThoughtIdIn(@Param("deepThoughtIds") List<Long> deepThoughtIds);
 
     void deleteByDeepThoughtId(Long deepThoughtId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM DeepThoughtReceiver dtr WHERE dtr.deepThought.id IN :deepThoughtIds")
+    void deleteByDeepThoughtIdIn(@Param("deepThoughtIds") List<Long> deepThoughtIds);
 
     @Query("""
         SELECT DISTINCT dtr FROM DeepThoughtReceiver dtr

--- a/src/main/java/com/afternote/domain/receiver/repository/DeliveryVerificationRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/DeliveryVerificationRepository.java
@@ -27,4 +27,6 @@ public interface DeliveryVerificationRepository extends JpaRepository<DeliveryVe
             Long userId,
             Long receiverId
     );
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/DiaryReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/DiaryReceiverRepository.java
@@ -2,6 +2,7 @@ package com.afternote.domain.receiver.repository;
 
 import com.afternote.domain.receiver.model.DiaryReceiver;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -22,6 +23,10 @@ public interface DiaryReceiverRepository extends JpaRepository<DiaryReceiver, Lo
     List<DiaryReceiver> findByDiaryIdIn(@Param("diaryIds") List<Long> diaryIds);
 
     void deleteByDiaryId(Long diaryId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM DiaryReceiver dr WHERE dr.diary.id IN :diaryIds")
+    void deleteByDiaryIdIn(@Param("diaryIds") List<Long> diaryIds);
 
     @Query("""
         SELECT dr FROM DiaryReceiver dr

--- a/src/main/java/com/afternote/domain/receiver/repository/ReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/ReceiverRepository.java
@@ -12,4 +12,6 @@ public interface ReceiverRepository extends JpaRepository<Receiver, Long> {
     Optional<Receiver> findByAuthCode(String authCode);
     List<Receiver> findAllByEmailIgnoreCaseOrderByIdDesc(String email);
     List<Receiver> findAllByUserId(Long userId);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/UserDailyQuestionReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/UserDailyQuestionReceiverRepository.java
@@ -2,6 +2,7 @@ package com.afternote.domain.receiver.repository;
 
 import com.afternote.domain.receiver.model.UserDailyQuestionReceiver;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -24,6 +25,10 @@ public interface UserDailyQuestionReceiverRepository extends JpaRepository<UserD
     );
 
     void deleteByUserDailyQuestionId(Long userDailyQuestionId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM UserDailyQuestionReceiver udqr WHERE udqr.userDailyQuestion.id IN :ids")
+    void deleteByUserDailyQuestionIdIn(@Param("ids") List<Long> ids);
 
     @Query("""
         SELECT udqr FROM UserDailyQuestionReceiver udqr

--- a/src/main/java/com/afternote/domain/receiver/repository/UserReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/UserReceiverRepository.java
@@ -21,4 +21,6 @@ public interface UserReceiverRepository extends JpaRepository<UserReceiver, Long
 
     // 특정 사용자의 특정 수신인 관계 조회
     Optional<UserReceiver> findByUserAndReceiverId(User user, Long receiverId);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/src/main/java/com/afternote/domain/timeletter/repository/TimeLetterRepository.java
+++ b/src/main/java/com/afternote/domain/timeletter/repository/TimeLetterRepository.java
@@ -4,6 +4,8 @@ import com.afternote.domain.timeletter.model.TimeLetter;
 import com.afternote.domain.timeletter.model.TimeLetterStatus;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -12,6 +14,9 @@ import java.util.Optional;
 
 @Repository
 public interface TimeLetterRepository extends JpaRepository<TimeLetter, Long> {
+
+    @Query("SELECT t.id FROM TimeLetter t WHERE t.user.id = :userId")
+    List<Long> findIdsByUserId(@Param("userId") Long userId);
 
     @EntityGraph(attributePaths = {"blocks"})
     List<TimeLetter> findByUserIdAndStatusOrderByCreatedAtDesc(Long userId, TimeLetterStatus status);

--- a/src/main/java/com/afternote/domain/user/controller/UserController.java
+++ b/src/main/java/com/afternote/domain/user/controller/UserController.java
@@ -193,7 +193,7 @@ public class UserController {
 
     @Operation(
             summary = "회원 탈퇴 API",
-            description = "로그인한 사용자의 계정을 삭제합니다. 모든 데이터가 영구적으로 삭제되며 복구할 수 없습니다."
+            description = "로그인한 사용자의 계정을 삭제합니다. 모든 데이터가 영구적으로 삭제되며, 동일 이메일은 탈퇴 후 30일간 재가입할 수 없습니다."
     )
     @DeleteMapping("/me")
     public ApiResponse<Void> deleteAccount(

--- a/src/main/java/com/afternote/domain/user/model/WithdrawnUser.java
+++ b/src/main/java/com/afternote/domain/user/model/WithdrawnUser.java
@@ -1,0 +1,44 @@
+package com.afternote.domain.user.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 탈퇴 이력. hard delete 후에도 동일 이메일 재가입 쿨다운(30일) 판단에 사용한다.
+ */
+@Entity
+@Table(
+        name = "withdrawn_user",
+        indexes = {
+                @Index(name = "idx_withdrawn_user_email_withdrawn_at", columnList = "email, withdrawn_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WithdrawnUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String email;
+
+    @Column(name = "withdrawn_at", nullable = false)
+    private LocalDateTime withdrawnAt;
+
+    @Column(name = "previous_user_id")
+    private Long previousUserId;
+
+    public static WithdrawnUser of(String email, Long previousUserId) {
+        WithdrawnUser row = new WithdrawnUser();
+        row.email = email;
+        row.previousUserId = previousUserId;
+        row.withdrawnAt = LocalDateTime.now();
+        return row;
+    }
+}

--- a/src/main/java/com/afternote/domain/user/repository/WithdrawnUserRepository.java
+++ b/src/main/java/com/afternote/domain/user/repository/WithdrawnUserRepository.java
@@ -1,0 +1,11 @@
+package com.afternote.domain.user.repository;
+
+import com.afternote.domain.user.model.WithdrawnUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface WithdrawnUserRepository extends JpaRepository<WithdrawnUser, Long> {
+
+    Optional<WithdrawnUser> findTopByEmailIgnoreCaseOrderByWithdrawnAtDesc(String email);
+}

--- a/src/main/java/com/afternote/domain/user/service/AccountWithdrawalService.java
+++ b/src/main/java/com/afternote/domain/user/service/AccountWithdrawalService.java
@@ -1,0 +1,132 @@
+package com.afternote.domain.user.service;
+
+import com.afternote.domain.afternote.repository.AfternoteRepository;
+import com.afternote.domain.auth.service.TokenService;
+import com.afternote.domain.dailyquestion.repository.UserDailyQuestionRepository;
+import com.afternote.domain.deepthought.repository.DeepThoughtCategoryRepository;
+import com.afternote.domain.deepthought.repository.DeepThoughtRepository;
+import com.afternote.domain.delivery.repository.DeliveryConditionRepository;
+import com.afternote.domain.diary.repository.DiaryRepository;
+import com.afternote.domain.mindrecord.emotion.repository.EmotionRepository;
+import com.afternote.domain.mindrecord.weekly.repository.WeeklyReportRepository;
+import com.afternote.domain.receiver.repository.AfternoteReceiverRepository;
+import com.afternote.domain.receiver.repository.DeepThoughtReceiverRepository;
+import com.afternote.domain.receiver.repository.DeliveryVerificationRepository;
+import com.afternote.domain.receiver.repository.DiaryReceiverRepository;
+import com.afternote.domain.receiver.repository.ReceiverRepository;
+import com.afternote.domain.receiver.repository.TimeLetterReceiverRepository;
+import com.afternote.domain.receiver.repository.UserDailyQuestionReceiverRepository;
+import com.afternote.domain.receiver.repository.UserReceiverRepository;
+import com.afternote.domain.timeletter.repository.TimeLetterMediaRepository;
+import com.afternote.domain.timeletter.repository.TimeLetterRepository;
+import com.afternote.domain.user.model.User;
+import com.afternote.domain.user.model.WithdrawnUser;
+import com.afternote.domain.user.repository.UserRepository;
+import com.afternote.domain.user.repository.WithdrawnUserRepository;
+import com.afternote.global.exception.CustomException;
+import com.afternote.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 회원 탈퇴: FK 순서로 종속 데이터를 지운 뒤 User hard delete.
+ * cascade만으로는 time_letter_receiver 등 조인 테이블이 남아 500이 난다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AccountWithdrawalService {
+
+    private final UserRepository userRepository;
+    private final WithdrawnUserRepository withdrawnUserRepository;
+    private final TokenService tokenService;
+
+    private final TimeLetterRepository timeLetterRepository;
+    private final TimeLetterReceiverRepository timeLetterReceiverRepository;
+    private final TimeLetterMediaRepository timeLetterMediaRepository;
+
+    private final DiaryRepository diaryRepository;
+    private final DiaryReceiverRepository diaryReceiverRepository;
+
+    private final DeepThoughtRepository deepThoughtRepository;
+    private final DeepThoughtReceiverRepository deepThoughtReceiverRepository;
+    private final DeepThoughtCategoryRepository deepThoughtCategoryRepository;
+
+    private final UserDailyQuestionRepository userDailyQuestionRepository;
+    private final UserDailyQuestionReceiverRepository userDailyQuestionReceiverRepository;
+
+    private final AfternoteRepository afternoteRepository;
+    private final AfternoteReceiverRepository afternoteReceiverRepository;
+
+    private final DeliveryConditionRepository deliveryConditionRepository;
+    private final DeliveryVerificationRepository deliveryVerificationRepository;
+
+    private final EmotionRepository emotionRepository;
+    private final WeeklyReportRepository weeklyReportRepository;
+
+    private final UserReceiverRepository userReceiverRepository;
+    private final ReceiverRepository receiverRepository;
+
+    @Transactional
+    public void withdraw(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        String email = user.getEmail();
+
+        // 1) 토큰 무효화 (refresh 전부 + access 차단용 revoke 플래그)
+        tokenService.revokeUserAccess(userId);
+        tokenService.deleteAllUserTokens(userId);
+
+        // 2) 콘텐츠-수신자 조인 테이블 선행 삭제 (FK 500 방지)
+        List<Long> timeLetterIds = timeLetterRepository.findIdsByUserId(userId);
+        if (!timeLetterIds.isEmpty()) {
+            timeLetterReceiverRepository.deleteByTimeLetterIdIn(timeLetterIds);
+            timeLetterMediaRepository.deleteByTimeLetterIdIn(timeLetterIds);
+        }
+
+        List<Long> diaryIds = diaryRepository.findIdsByUserId(userId);
+        if (!diaryIds.isEmpty()) {
+            diaryReceiverRepository.deleteByDiaryIdIn(diaryIds);
+        }
+
+        List<Long> deepThoughtIds = deepThoughtRepository.findIdsByUserId(userId);
+        if (!deepThoughtIds.isEmpty()) {
+            deepThoughtReceiverRepository.deleteByDeepThoughtIdIn(deepThoughtIds);
+        }
+
+        List<Long> dailyQuestionIds = userDailyQuestionRepository.findIdsByUserId(userId);
+        if (!dailyQuestionIds.isEmpty()) {
+            userDailyQuestionReceiverRepository.deleteByUserDailyQuestionIdIn(dailyQuestionIds);
+        }
+
+        List<Long> afternoteIds = afternoteRepository.findIdsByUserId(userId);
+        if (!afternoteIds.isEmpty()) {
+            afternoteReceiverRepository.deleteByAfternoteIdIn(afternoteIds);
+        }
+
+        // 3) 전달 조건/검증·마인드 리포트 등 User 직접 참조
+        deliveryConditionRepository.deleteByUserId(userId);
+        deliveryVerificationRepository.deleteByUserId(userId);
+        emotionRepository.deleteByUser_Id(userId);
+        weeklyReportRepository.deleteByUser_Id(userId);
+
+        // 4) 깊은생각 카테고리 (DeepThought.category FK 먼저 해제)
+        deepThoughtRepository.clearCategoryByUserId(userId);
+        deepThoughtCategoryRepository.deleteByUser_Id(userId);
+
+        // 5) 수신자 (UserReceiver → Receiver). 다른 조인이 이미 정리된 뒤 삭제.
+        userReceiverRepository.deleteByUser_Id(userId);
+        receiverRepository.deleteByUserId(userId);
+
+        // 6) 탈퇴 이력 저장 후 User hard delete (잔여 cascade: timeLetters, diaries, ...)
+        withdrawnUserRepository.save(WithdrawnUser.of(email, userId));
+        userRepository.delete(user);
+
+        log.info("Account withdrawn. previousUserId={}, email={}", userId, email);
+    }
+}

--- a/src/main/java/com/afternote/domain/user/service/UserService.java
+++ b/src/main/java/com/afternote/domain/user/service/UserService.java
@@ -41,6 +41,7 @@ public class UserService {
     private final com.afternote.domain.auth.service.TokenService tokenService;
     private final SocialLoginFactory socialLoginFactory;
     private final UserProviderRepository userProviderRepository;
+    private final AccountWithdrawalService accountWithdrawalService;
 
     public UserResponse getMyProfile(Long userId) {
 
@@ -246,13 +247,7 @@ public class UserService {
 
     @Transactional
     public void deleteAccount(Long userId) {
-        User user = findUserById(userId);
-        
-        // 1. Redis에서 해당 유저의 모든 refresh token 삭제
-        tokenService.deleteAllUserTokens(userId);
-        
-        // 2. User 엔티티 삭제 (cascade로 providers도 자동 삭제됨)
-        userRepository.delete(user);
+        accountWithdrawalService.withdraw(userId);
     }
 
     private User findUserById(Long userId) {

--- a/src/main/java/com/afternote/domain/user/service/WithdrawalCooldownService.java
+++ b/src/main/java/com/afternote/domain/user/service/WithdrawalCooldownService.java
@@ -1,0 +1,33 @@
+package com.afternote.domain.user.service;
+
+import com.afternote.domain.user.repository.WithdrawnUserRepository;
+import com.afternote.global.exception.CustomException;
+import com.afternote.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WithdrawalCooldownService {
+
+    public static final int COOLDOWN_DAYS = 30;
+
+    private final WithdrawnUserRepository withdrawnUserRepository;
+
+    public void assertNotInCooldown(String email) {
+        if (email == null || email.isBlank()) {
+            return;
+        }
+        withdrawnUserRepository.findTopByEmailIgnoreCaseOrderByWithdrawnAtDesc(email.trim())
+                .ifPresent(withdrawn -> {
+                    LocalDateTime until = withdrawn.getWithdrawnAt().plusDays(COOLDOWN_DAYS);
+                    if (LocalDateTime.now().isBefore(until)) {
+                        throw new CustomException(ErrorCode.WITHDRAWAL_COOLDOWN);
+                    }
+                });
+    }
+}

--- a/src/main/java/com/afternote/global/exception/ErrorCode.java
+++ b/src/main/java/com/afternote/global/exception/ErrorCode.java
@@ -102,6 +102,9 @@ public enum ErrorCode {
     // 가입되지 않은 이메일
     EMAIL_NOT_REGISTERED(HttpStatus.BAD_REQUEST, 1219, "가입되지 않은 이메일입니다."),
 
+    // 탈퇴 후 재가입 쿨다운
+    WITHDRAWAL_COOLDOWN(HttpStatus.CONFLICT, 1221, "탈퇴 후 30일 동안 동일 이메일로 재가입할 수 없습니다."),
+
     // ======================================
     // 4. 타임레터 관련 오류 (code: 1300 ~ 1399)
     // ======================================

--- a/src/main/java/com/afternote/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/afternote/global/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.afternote.global.jwt;
 
+import com.afternote.domain.auth.service.TokenService;
+import com.afternote.domain.user.repository.UserRepository;
 import com.afternote.global.resolver.UserIdArgumentResolver;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -23,6 +25,8 @@ import java.util.Collections;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final TokenService tokenService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -36,15 +40,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // 3. 토큰에서 ID(Subject) 꺼내기
             Long userId = jwtTokenProvider.getUserId(token);
 
-            // 4. Request Attribute에 userId 저장 (컨트롤러에서 @AuthUser로 접근 가능)
-            request.setAttribute(UserIdArgumentResolver.USER_ID_ATTRIBUTE, userId);
+            // 탈퇴/삭제된 계정 또는 강제 만료된 accessToken 은 인증하지 않는다
+            if (!tokenService.isAccessRevoked(userId) && userRepository.existsById(userId)) {
+                // 4. Request Attribute에 userId 저장 (컨트롤러에서 @AuthUser로 접근 가능)
+                request.setAttribute(UserIdArgumentResolver.USER_ID_ATTRIBUTE, userId);
 
-            // 5. 유저 정보를 임시로 만들어서 SecurityContext에 넣어주기 (로그인 인정)
-            // (권한은 일단 USER로 통일. 실제로는 DB에서 조회해서 넣을 수도 있음)
-            UserDetails userDetails = new User(String.valueOf(userId), "", Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")));
-            Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+                // 5. 유저 정보를 임시로 만들어서 SecurityContext에 넣어주기 (로그인 인정)
+                UserDetails userDetails = new User(String.valueOf(userId), "", Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")));
+                Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
 
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
         }
 
         // 6. 다음 필터로 넘기기

--- a/src/test/java/com/afternote/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/afternote/domain/auth/service/AuthServiceTest.java
@@ -7,6 +7,7 @@ import com.afternote.domain.user.model.AuthProvider;
 import com.afternote.domain.user.model.User;
 import com.afternote.domain.user.model.UserStatus;
 import com.afternote.domain.user.repository.UserRepository;
+import com.afternote.domain.user.service.WithdrawalCooldownService;
 import com.afternote.global.exception.CustomException;
 import com.afternote.global.exception.ErrorCode;
 import com.afternote.global.jwt.JwtTokenProvider;
@@ -26,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,6 +50,9 @@ class AuthServiceTest {
 
     @Mock
     private EmailService emailService;
+
+    @Mock
+    private WithdrawalCooldownService withdrawalCooldownService;
 
     @Mock
     private SocialLoginFactory socialLoginFactory;
@@ -78,6 +83,21 @@ class AuthServiceTest {
         assertThatThrownBy(() -> authService.signup(request))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.EMAIL_NOT_VERIFIED));
+    }
+
+    @Test
+    @DisplayName("이메일 인증번호 발송 실패 - 탈퇴 후 30일 쿨다운")
+    void emailSend_WithdrawalCooldown_Fail() {
+        EmailSendRequest request = org.mockito.Mockito.mock(EmailSendRequest.class);
+        given(request.getEmail()).willReturn("gone@test.com");
+        given(userRepository.existsByEmail("gone@test.com")).willReturn(false);
+        willThrow(new CustomException(ErrorCode.WITHDRAWAL_COOLDOWN))
+                .given(withdrawalCooldownService).assertNotInCooldown("gone@test.com");
+
+        assertThatThrownBy(() -> authService.emailSend(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.WITHDRAWAL_COOLDOWN));
     }
 
     @Test

--- a/src/test/java/com/afternote/domain/user/service/AccountWithdrawalServiceTest.java
+++ b/src/test/java/com/afternote/domain/user/service/AccountWithdrawalServiceTest.java
@@ -1,0 +1,108 @@
+package com.afternote.domain.user.service;
+
+import com.afternote.domain.afternote.repository.AfternoteRepository;
+import com.afternote.domain.auth.service.TokenService;
+import com.afternote.domain.dailyquestion.repository.UserDailyQuestionRepository;
+import com.afternote.domain.deepthought.repository.DeepThoughtCategoryRepository;
+import com.afternote.domain.deepthought.repository.DeepThoughtRepository;
+import com.afternote.domain.delivery.repository.DeliveryConditionRepository;
+import com.afternote.domain.diary.repository.DiaryRepository;
+import com.afternote.domain.mindrecord.emotion.repository.EmotionRepository;
+import com.afternote.domain.mindrecord.weekly.repository.WeeklyReportRepository;
+import com.afternote.domain.receiver.repository.AfternoteReceiverRepository;
+import com.afternote.domain.receiver.repository.DeepThoughtReceiverRepository;
+import com.afternote.domain.receiver.repository.DeliveryVerificationRepository;
+import com.afternote.domain.receiver.repository.DiaryReceiverRepository;
+import com.afternote.domain.receiver.repository.ReceiverRepository;
+import com.afternote.domain.receiver.repository.TimeLetterReceiverRepository;
+import com.afternote.domain.receiver.repository.UserDailyQuestionReceiverRepository;
+import com.afternote.domain.receiver.repository.UserReceiverRepository;
+import com.afternote.domain.timeletter.repository.TimeLetterMediaRepository;
+import com.afternote.domain.timeletter.repository.TimeLetterRepository;
+import com.afternote.domain.user.model.AuthProvider;
+import com.afternote.domain.user.model.User;
+import com.afternote.domain.user.model.UserStatus;
+import com.afternote.domain.user.repository.UserRepository;
+import com.afternote.domain.user.repository.WithdrawnUserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AccountWithdrawalServiceTest {
+
+    @InjectMocks
+    private AccountWithdrawalService accountWithdrawalService;
+
+    @Mock private UserRepository userRepository;
+    @Mock private WithdrawnUserRepository withdrawnUserRepository;
+    @Mock private TokenService tokenService;
+    @Mock private TimeLetterRepository timeLetterRepository;
+    @Mock private TimeLetterReceiverRepository timeLetterReceiverRepository;
+    @Mock private TimeLetterMediaRepository timeLetterMediaRepository;
+    @Mock private DiaryRepository diaryRepository;
+    @Mock private DiaryReceiverRepository diaryReceiverRepository;
+    @Mock private DeepThoughtRepository deepThoughtRepository;
+    @Mock private DeepThoughtReceiverRepository deepThoughtReceiverRepository;
+    @Mock private DeepThoughtCategoryRepository deepThoughtCategoryRepository;
+    @Mock private UserDailyQuestionRepository userDailyQuestionRepository;
+    @Mock private UserDailyQuestionReceiverRepository userDailyQuestionReceiverRepository;
+    @Mock private AfternoteRepository afternoteRepository;
+    @Mock private AfternoteReceiverRepository afternoteReceiverRepository;
+    @Mock private DeliveryConditionRepository deliveryConditionRepository;
+    @Mock private DeliveryVerificationRepository deliveryVerificationRepository;
+    @Mock private EmotionRepository emotionRepository;
+    @Mock private WeeklyReportRepository weeklyReportRepository;
+    @Mock private UserReceiverRepository userReceiverRepository;
+    @Mock private ReceiverRepository receiverRepository;
+
+    @Test
+    @DisplayName("탈퇴 시 타임레터 수신자 조인을 먼저 삭제하고 이력을 남긴다")
+    void withdraw_DeletesTimeLetterReceiversFirst() {
+        User user = User.builder()
+                .email("u@test.com")
+                .password("pw")
+                .name("tester")
+                .status(UserStatus.ACTIVE)
+                .provider(AuthProvider.LOCAL)
+                .build();
+        ReflectionTestUtils.setField(user, "id", 10L);
+
+        given(userRepository.findById(10L)).willReturn(Optional.of(user));
+        given(timeLetterRepository.findIdsByUserId(10L)).willReturn(List.of(100L, 101L));
+        given(diaryRepository.findIdsByUserId(10L)).willReturn(List.of());
+        given(deepThoughtRepository.findIdsByUserId(10L)).willReturn(List.of());
+        given(userDailyQuestionRepository.findIdsByUserId(10L)).willReturn(List.of());
+        given(afternoteRepository.findIdsByUserId(10L)).willReturn(List.of());
+
+        accountWithdrawalService.withdraw(10L);
+
+        verify(tokenService).revokeUserAccess(10L);
+        verify(tokenService).deleteAllUserTokens(10L);
+        verify(timeLetterReceiverRepository).deleteByTimeLetterIdIn(List.of(100L, 101L));
+        verify(timeLetterMediaRepository).deleteByTimeLetterIdIn(List.of(100L, 101L));
+        verify(receiverRepository).deleteByUserId(10L);
+
+        ArgumentCaptor<com.afternote.domain.user.model.WithdrawnUser> captor =
+                ArgumentCaptor.forClass(com.afternote.domain.user.model.WithdrawnUser.class);
+        verify(withdrawnUserRepository).save(captor.capture());
+        assertThat(captor.getValue().getEmail()).isEqualTo("u@test.com");
+        assertThat(captor.getValue().getPreviousUserId()).isEqualTo(10L);
+
+        verify(userRepository).delete(eq(user));
+    }
+}

--- a/src/test/java/com/afternote/domain/user/service/UserServiceCreateReceiverTest.java
+++ b/src/test/java/com/afternote/domain/user/service/UserServiceCreateReceiverTest.java
@@ -58,6 +58,8 @@ class UserServiceCreateReceiverTest {
     private SocialLoginFactory socialLoginFactory;
     @Mock
     private UserProviderRepository userProviderRepository;
+    @Mock
+    private AccountWithdrawalService accountWithdrawalService;
 
     @Test
     @DisplayName("수신자 등록 실패 - 전화번호 형식")

--- a/src/test/java/com/afternote/domain/user/service/WithdrawalCooldownServiceTest.java
+++ b/src/test/java/com/afternote/domain/user/service/WithdrawalCooldownServiceTest.java
@@ -1,0 +1,57 @@
+package com.afternote.domain.user.service;
+
+import com.afternote.domain.user.model.WithdrawnUser;
+import com.afternote.domain.user.repository.WithdrawnUserRepository;
+import com.afternote.global.exception.CustomException;
+import com.afternote.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class WithdrawalCooldownServiceTest {
+
+    @InjectMocks
+    private WithdrawalCooldownService withdrawalCooldownService;
+
+    @Mock
+    private WithdrawnUserRepository withdrawnUserRepository;
+
+    @Test
+    @DisplayName("탈퇴 30일 이내면 WITHDRAWAL_COOLDOWN")
+    void withinCooldown_Fail() {
+        WithdrawnUser withdrawn = WithdrawnUser.of("a@test.com", 1L);
+        ReflectionTestUtils.setField(withdrawn, "withdrawnAt", LocalDateTime.now().minusDays(1));
+        given(withdrawnUserRepository.findTopByEmailIgnoreCaseOrderByWithdrawnAtDesc("a@test.com"))
+                .willReturn(Optional.of(withdrawn));
+
+        assertThatThrownBy(() -> withdrawalCooldownService.assertNotInCooldown("a@test.com"))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.WITHDRAWAL_COOLDOWN));
+    }
+
+    @Test
+    @DisplayName("탈퇴 30일 지나면 통과")
+    void afterCooldown_Ok() {
+        WithdrawnUser withdrawn = WithdrawnUser.of("a@test.com", 1L);
+        ReflectionTestUtils.setField(withdrawn, "withdrawnAt", LocalDateTime.now().minusDays(31));
+        given(withdrawnUserRepository.findTopByEmailIgnoreCaseOrderByWithdrawnAtDesc("a@test.com"))
+                .willReturn(Optional.of(withdrawn));
+
+        assertThatCode(() -> withdrawalCooldownService.assertNotInCooldown("a@test.com"))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Summary
- **#87** `DELETE /users/me` — `time_letter_receiver` 등 조인/종속 데이터를 **순서대로 삭제**한 뒤 User hard delete (타임레터 있어도 200)
- **#88** 앱 고지와 동일하게 **탈퇴 후 30일 재가입 제한** — `withdrawn_user` 이력 저장, `auth/email/send`·`sign-up`·소셜 신규 가입에서 **409 / 1221** 차단
- **#89** JWT 필터에서 **유저 존재 여부 + Redis access revoke** 확인 — 탈퇴 계정 accessToken 으로는 더 이상 인증되지 않음

## Policy note
- 30일 제한은 **서버 정책으로 존재**하는 것으로 반영했습니다 (앱 고지 문구와 일치).
- 개인정보는 기존처럼 hard delete, 재가입 판별용으로 **email + withdrawn_at 이력만** 남깁니다.

## Test plan
- [ ] 수신자+타임레터(SCHEDULED/DRAFT) 있는 계정 `DELETE /users/me` → 200
- [ ] 탈퇴 직후 같은 이메일 `POST /auth/email/send` → 409 code 1221
- [ ] 탈퇴 직후 `sign-up` → 409 code 1221
- [ ] 탈퇴 직전 accessToken 으로 `GET /time-letters` 등 → 401 (인증 필요)
- [ ] 타임레터 없는 계정 탈퇴는 기존처럼 200

Closes #87
Closes #88
Closes #89


Made with [Cursor](https://cursor.com)