### PR TITLE
fix: 수신자 삭제 API 및 미지원 메서드 405 (#91)

### DIFF
--- a/src/main/java/com/afternote/domain/delivery/repository/DeliveryConditionRepository.java
+++ b/src/main/java/com/afternote/domain/delivery/repository/DeliveryConditionRepository.java
@@ -24,4 +24,6 @@ public interface DeliveryConditionRepository extends JpaRepository<DeliveryCondi
     boolean existsByReceiverIdAndState(Long receiverId, ConditionState state);
 
     void deleteByUserId(Long userId);
+
+    void deleteByReceiverId(Long receiverId);
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/DeliveryVerificationRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/DeliveryVerificationRepository.java
@@ -29,4 +29,6 @@ public interface DeliveryVerificationRepository extends JpaRepository<DeliveryVe
     );
 
     void deleteByUserId(Long userId);
+
+    void deleteByReceiverId(Long receiverId);
 }

--- a/src/main/java/com/afternote/domain/user/controller/UserController.java
+++ b/src/main/java/com/afternote/domain/user/controller/UserController.java
@@ -218,5 +218,18 @@ public class UserController {
         );
     }
 
+    @Operation(
+            summary = "수신자 삭제 API",
+            description = "등록한 수신자를 삭제합니다. 타임레터·애프터노트 등 콘텐츠에 이미 연결된 수신자는 삭제할 수 없습니다."
+    )
+    @DeleteMapping("/receivers/{receiverId}")
+    public ApiResponse<Void> deleteReceiver(
+            @Parameter(hidden = true) @UserId Long userId,
+            @PathVariable Long receiverId
+    ) {
+        userService.deleteReceiver(userId, receiverId);
+        return ApiResponse.success(null);
+    }
+
 
 }

--- a/src/main/java/com/afternote/domain/user/service/ReceiverDeletionService.java
+++ b/src/main/java/com/afternote/domain/user/service/ReceiverDeletionService.java
@@ -1,0 +1,71 @@
+package com.afternote.domain.user.service;
+
+import com.afternote.domain.delivery.repository.DeliveryConditionRepository;
+import com.afternote.domain.receiver.model.Receiver;
+import com.afternote.domain.receiver.model.UserReceiver;
+import com.afternote.domain.receiver.repository.AfternoteReceiverRepository;
+import com.afternote.domain.receiver.repository.DeepThoughtReceiverRepository;
+import com.afternote.domain.receiver.repository.DeliveryVerificationRepository;
+import com.afternote.domain.receiver.repository.DiaryReceiverRepository;
+import com.afternote.domain.receiver.repository.ReceiverRepository;
+import com.afternote.domain.receiver.repository.TimeLetterReceiverRepository;
+import com.afternote.domain.receiver.repository.UserDailyQuestionReceiverRepository;
+import com.afternote.domain.receiver.repository.UserReceiverRepository;
+import com.afternote.domain.user.model.User;
+import com.afternote.domain.user.repository.UserRepository;
+import com.afternote.global.exception.CustomException;
+import com.afternote.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 수신자 삭제.
+ * 정책: 콘텐츠(타임레터·애프터노트·일기 등)에 연결된 수신자는 삭제 거부(409).
+ * 연결이 없으면 전달조건/인증이력·UserReceiver·Receiver 를 hard delete.
+ */
+@Service
+@RequiredArgsConstructor
+public class ReceiverDeletionService {
+
+    private final UserRepository userRepository;
+    private final UserReceiverRepository userReceiverRepository;
+    private final ReceiverRepository receiverRepository;
+
+    private final TimeLetterReceiverRepository timeLetterReceiverRepository;
+    private final AfternoteReceiverRepository afternoteReceiverRepository;
+    private final DiaryReceiverRepository diaryReceiverRepository;
+    private final DeepThoughtReceiverRepository deepThoughtReceiverRepository;
+    private final UserDailyQuestionReceiverRepository userDailyQuestionReceiverRepository;
+
+    private final DeliveryConditionRepository deliveryConditionRepository;
+    private final DeliveryVerificationRepository deliveryVerificationRepository;
+
+    @Transactional
+    public void deleteReceiver(Long userId, Long receiverId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        UserReceiver userReceiver = userReceiverRepository.findByUserAndReceiverId(user, receiverId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECEIVER_NOT_FOUND));
+
+        if (isLinkedToContent(receiverId)) {
+            throw new CustomException(ErrorCode.RECEIVER_IN_USE);
+        }
+
+        deliveryConditionRepository.deleteByReceiverId(receiverId);
+        deliveryVerificationRepository.deleteByReceiverId(receiverId);
+
+        Receiver receiver = userReceiver.getReceiver();
+        userReceiverRepository.delete(userReceiver);
+        receiverRepository.delete(receiver);
+    }
+
+    private boolean isLinkedToContent(Long receiverId) {
+        return timeLetterReceiverRepository.existsByReceiverId(receiverId)
+                || afternoteReceiverRepository.existsByReceiverId(receiverId)
+                || diaryReceiverRepository.existsByReceiverId(receiverId)
+                || deepThoughtReceiverRepository.existsByReceiverId(receiverId)
+                || userDailyQuestionReceiverRepository.existsByReceiverId(receiverId);
+    }
+}

--- a/src/main/java/com/afternote/domain/user/service/UserService.java
+++ b/src/main/java/com/afternote/domain/user/service/UserService.java
@@ -42,6 +42,7 @@ public class UserService {
     private final SocialLoginFactory socialLoginFactory;
     private final UserProviderRepository userProviderRepository;
     private final AccountWithdrawalService accountWithdrawalService;
+    private final ReceiverDeletionService receiverDeletionService;
 
     public UserResponse getMyProfile(Long userId) {
 
@@ -248,6 +249,11 @@ public class UserService {
     @Transactional
     public void deleteAccount(Long userId) {
         accountWithdrawalService.withdraw(userId);
+    }
+
+    @Transactional
+    public void deleteReceiver(Long userId, Long receiverId) {
+        receiverDeletionService.deleteReceiver(userId, receiverId);
     }
 
     private User findUserById(Long userId) {

--- a/src/main/java/com/afternote/global/exception/ErrorCode.java
+++ b/src/main/java/com/afternote/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     NOT_ENOUGH_PERMISSION(HttpStatus.FORBIDDEN, 1002, "권한이 부족합니다."),
     ENDPOINT_NOT_FOUND(HttpStatus.NOT_FOUND, 1003, "존재하지 않는 엔드포인트입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 1004, "서버 내부 오류가 발생했습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 1005, "허용되지 않은 HTTP 메서드입니다."),
 
     // ======================================
     // 2. 토큰 관련 오류 (code: 1100 ~ 1199)
@@ -156,6 +157,7 @@ public enum ErrorCode {
     LEAVE_MESSAGE_BODY_TOO_LONG(HttpStatus.BAD_REQUEST, 1626, "남기실 말씀 본문은 2000자를 초과할 수 없습니다."),
     INVALID_PHONE_FORMAT(HttpStatus.BAD_REQUEST, 1627, "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)"),
     DUPLICATE_RECEIVER_PHONE(HttpStatus.CONFLICT, 1628, "이미 등록된 수신자 전화번호입니다."),
+    RECEIVER_IN_USE(HttpStatus.CONFLICT, 1629, "이미 콘텐츠에 연결된 수신자는 삭제할 수 없습니다. 연결을 해제한 뒤 다시 시도해주세요."),
 
     // ======================================                                                                                                                                                               
     // 7. 암호화 관련 오류 (code: 1700 ~ 1799)                                                                                                                                                                    

--- a/src/main/java/com/afternote/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/afternote/global/exception/GlobalExceptionHandler.java
@@ -7,12 +7,14 @@ import org.springframework.beans.TypeMismatchException;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -68,7 +70,25 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(400, ErrorCode.INVALID_INPUT_VALUE.getCode(), "요청 파라미터 형식이 올바르지 않습니다."));
     }
 
-    // 5. 그 외 예상치 못한 에러 — 상세는 로그에만, 응답은 일반 메시지
+    // 5. 허용되지 않은 HTTP 메서드
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.error(errorCode));
+    }
+
+    // 5-1. 존재하지 않는 엔드포인트 (설정 시 NoHandlerFoundException 발생)
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNoHandlerFound(NoHandlerFoundException e) {
+        ErrorCode errorCode = ErrorCode.ENDPOINT_NOT_FOUND;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.error(errorCode));
+    }
+
+    // 6. 그 외 예상치 못한 에러 — 상세는 로그에만, 응답은 일반 메시지
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         log.error("Unhandled exception", e);

--- a/src/test/java/com/afternote/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/afternote/domain/user/controller/UserControllerTest.java
@@ -206,6 +206,16 @@ class UserControllerTest {
         verify(userService).updateReceiver(eq(USER_ID), eq(2L), any());
     }
 
+    @Test
+    @DisplayName("수신자 삭제 API 성공")
+    void deleteReceiver_Success() throws Exception {
+        mockMvc.perform(delete("/api/v1/users/receivers/{receiverId}", 17L)
+                        .requestAttr(UserIdArgumentResolver.USER_ID_ATTRIBUTE, USER_ID))
+                .andExpect(status().isOk());
+
+        verify(userService).deleteReceiver(USER_ID, 17L);
+    }
+
     private static class UserIdTestArgumentResolver implements HandlerMethodArgumentResolver {
         @Override
         public boolean supportsParameter(MethodParameter parameter) {

--- a/src/test/java/com/afternote/domain/user/service/ReceiverDeletionServiceTest.java
+++ b/src/test/java/com/afternote/domain/user/service/ReceiverDeletionServiceTest.java
@@ -1,0 +1,116 @@
+package com.afternote.domain.user.service;
+
+import com.afternote.domain.delivery.repository.DeliveryConditionRepository;
+import com.afternote.domain.receiver.model.Receiver;
+import com.afternote.domain.receiver.model.UserReceiver;
+import com.afternote.domain.receiver.repository.AfternoteReceiverRepository;
+import com.afternote.domain.receiver.repository.DeepThoughtReceiverRepository;
+import com.afternote.domain.receiver.repository.DeliveryVerificationRepository;
+import com.afternote.domain.receiver.repository.DiaryReceiverRepository;
+import com.afternote.domain.receiver.repository.ReceiverRepository;
+import com.afternote.domain.receiver.repository.TimeLetterReceiverRepository;
+import com.afternote.domain.receiver.repository.UserDailyQuestionReceiverRepository;
+import com.afternote.domain.receiver.repository.UserReceiverRepository;
+import com.afternote.domain.user.model.AuthProvider;
+import com.afternote.domain.user.model.User;
+import com.afternote.domain.user.model.UserStatus;
+import com.afternote.domain.user.repository.UserRepository;
+import com.afternote.global.exception.CustomException;
+import com.afternote.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ReceiverDeletionServiceTest {
+
+    @InjectMocks
+    private ReceiverDeletionService receiverDeletionService;
+
+    @Mock private UserRepository userRepository;
+    @Mock private UserReceiverRepository userReceiverRepository;
+    @Mock private ReceiverRepository receiverRepository;
+    @Mock private TimeLetterReceiverRepository timeLetterReceiverRepository;
+    @Mock private AfternoteReceiverRepository afternoteReceiverRepository;
+    @Mock private DiaryReceiverRepository diaryReceiverRepository;
+    @Mock private DeepThoughtReceiverRepository deepThoughtReceiverRepository;
+    @Mock private UserDailyQuestionReceiverRepository userDailyQuestionReceiverRepository;
+    @Mock private DeliveryConditionRepository deliveryConditionRepository;
+    @Mock private DeliveryVerificationRepository deliveryVerificationRepository;
+
+    @Test
+    @DisplayName("콘텐츠에 연결된 수신자 삭제 거부")
+    void deleteReceiver_LinkedToContent_Fail() {
+        User user = sampleUser(1L);
+        Receiver receiver = sampleReceiver(17L, 1L);
+        UserReceiver link = UserReceiver.builder().user(user).receiver(receiver).build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userReceiverRepository.findByUserAndReceiverId(user, 17L)).willReturn(Optional.of(link));
+        given(timeLetterReceiverRepository.existsByReceiverId(17L)).willReturn(true);
+
+        assertThatThrownBy(() -> receiverDeletionService.deleteReceiver(1L, 17L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.RECEIVER_IN_USE));
+
+        verify(receiverRepository, never()).delete(receiver);
+    }
+
+    @Test
+    @DisplayName("연결 없는 수신자 hard delete")
+    void deleteReceiver_Unlinked_Success() {
+        User user = sampleUser(1L);
+        Receiver receiver = sampleReceiver(17L, 1L);
+        UserReceiver link = UserReceiver.builder().user(user).receiver(receiver).build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userReceiverRepository.findByUserAndReceiverId(user, 17L)).willReturn(Optional.of(link));
+        given(timeLetterReceiverRepository.existsByReceiverId(17L)).willReturn(false);
+        given(afternoteReceiverRepository.existsByReceiverId(17L)).willReturn(false);
+        given(diaryReceiverRepository.existsByReceiverId(17L)).willReturn(false);
+        given(deepThoughtReceiverRepository.existsByReceiverId(17L)).willReturn(false);
+        given(userDailyQuestionReceiverRepository.existsByReceiverId(17L)).willReturn(false);
+
+        receiverDeletionService.deleteReceiver(1L, 17L);
+
+        verify(deliveryConditionRepository).deleteByReceiverId(17L);
+        verify(deliveryVerificationRepository).deleteByReceiverId(17L);
+        verify(userReceiverRepository).delete(link);
+        verify(receiverRepository).delete(receiver);
+    }
+
+    private static User sampleUser(Long id) {
+        User user = User.builder()
+                .email("u@test.com")
+                .password("pw")
+                .name("tester")
+                .status(UserStatus.ACTIVE)
+                .provider(AuthProvider.LOCAL)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private static Receiver sampleReceiver(Long id, Long userId) {
+        Receiver receiver = Receiver.builder()
+                .name("kim")
+                .relation("아들")
+                .userId(userId)
+                .build();
+        ReflectionTestUtils.setField(receiver, "id", id);
+        return receiver;
+    }
+}

--- a/src/test/java/com/afternote/domain/user/service/UserServiceCreateReceiverTest.java
+++ b/src/test/java/com/afternote/domain/user/service/UserServiceCreateReceiverTest.java
@@ -60,6 +60,8 @@ class UserServiceCreateReceiverTest {
     private UserProviderRepository userProviderRepository;
     @Mock
     private AccountWithdrawalService accountWithdrawalService;
+    @Mock
+    private ReceiverDeletionService receiverDeletionService;
 
     @Test
     @DisplayName("수신자 등록 실패 - 전화번호 형식")

--- a/src/test/java/com/afternote/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/afternote/global/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,26 @@
+package com.afternote.global.exception;
+
+import com.afternote.global.common.ApiResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    @DisplayName("허용되지 않은 메서드는 405 / 1005")
+    void methodNotAllowed() {
+        ResponseEntity<ApiResponse<Void>> response = handler.handleMethodNotSupported(
+                new HttpRequestMethodNotSupportedException("DELETE")
+        );
+
+        assertThat(response.getStatusCode().value()).isEqualTo(405);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.METHOD_NOT_ALLOWED.getCode());
+    }
+}


### PR DESCRIPTION
## Summary
- `DELETE /api/v1/users/receivers/{receiverId}` 추가
- 콘텐츠(타임레터·애프터노트·일기·깊은생각·데일리질문)에 연결된 수신자는 `409 / 1629`로 삭제 거부, 미연결 시 hard delete
- 지원하지 않는 HTTP 메서드 요청을 `405 / 1005`로 응답 (기존 500 방지)

## Test plan
- [ ] `DELETE /api/v1/users/receivers/{receiverId}` — 미연결 수신자 삭제 성공 (`200`, data null)
- [ ] 본인 소유가 아닌/없는 receiverId → `404 / 1608`
- [ ] 타임레터·애프터노트 등에 연결된 수신자 → `409 / 1629`
- [ ] 삭제 후 수신자 목록에서 사라지는지 확인
- [ ] 미지원 메서드 호출 시 `405 / 1005` (500 아님)
- [ ] `./gradlew test --tests ReceiverDeletionServiceTest --tests GlobalExceptionHandlerTest --tests UserControllerTest`


Made with [Cursor](https://cursor.com)