### PR TITLE
fix: 없는 경로·미지원 메서드 요청 404/405 응답 (#97)

### DIFF
--- a/src/main/java/com/afternote/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/afternote/global/exception/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -70,7 +71,7 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(400, ErrorCode.INVALID_INPUT_VALUE.getCode(), "요청 파라미터 형식이 올바르지 않습니다."));
     }
 
-    // 5. 허용되지 않은 HTTP 메서드
+    // 5. 허용되지 않은 HTTP 메서드 (예: POST만 있는 path에 DELETE)
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ApiResponse<Void>> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
         ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
@@ -79,9 +80,11 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(errorCode));
     }
 
-    // 5-1. 존재하지 않는 엔드포인트 (설정 시 NoHandlerFoundException 발생)
-    @ExceptionHandler(NoHandlerFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleNoHandlerFound(NoHandlerFoundException e) {
+    // 5-1. 존재하지 않는 경로
+    // Spring Boot 3.2+ 는 ResourceHttpRequestHandler 가 NoResourceFoundException 을 던지고,
+    // 이를 잡지 않으면 아래 Exception 핸들러가 500/1004 로 삼킨다.
+    @ExceptionHandler({NoResourceFoundException.class, NoHandlerFoundException.class})
+    public ResponseEntity<ApiResponse<Void>> handleNotFound(Exception e) {
         ErrorCode errorCode = ErrorCode.ENDPOINT_NOT_FOUND;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())

--- a/src/test/java/com/afternote/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/afternote/global/exception/GlobalExceptionHandlerTest.java
@@ -3,8 +3,11 @@ package com.afternote.global.exception;
 import com.afternote.global.common.ApiResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,7 +16,7 @@ class GlobalExceptionHandlerTest {
     private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
 
     @Test
-    @DisplayName("허용되지 않은 메서드는 405 / 1005")
+    @DisplayName("허용되지 않은 메서드는 405 / 1005 — HTTP status 와 봉투 status 일치")
     void methodNotAllowed() {
         ResponseEntity<ApiResponse<Void>> response = handler.handleMethodNotSupported(
                 new HttpRequestMethodNotSupportedException("DELETE")
@@ -21,6 +24,35 @@ class GlobalExceptionHandlerTest {
 
         assertThat(response.getStatusCode().value()).isEqualTo(405);
         assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(405);
         assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.METHOD_NOT_ALLOWED.getCode());
+        assertThat(response.getBody().getMessage()).isEqualTo(ErrorCode.METHOD_NOT_ALLOWED.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 경로는 404 / 1003 (NoResourceFoundException) — Boot 3.2+ 라우팅 404")
+    void noResourceFound() {
+        ResponseEntity<ApiResponse<Void>> response = handler.handleNotFound(
+                new NoResourceFoundException(HttpMethod.GET, "api/v1/no-such-endpoint")
+        );
+
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(404);
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.ENDPOINT_NOT_FOUND.getCode());
+        assertThat(response.getBody().getMessage()).isEqualTo(ErrorCode.ENDPOINT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 경로는 404 / 1003 (NoHandlerFoundException)")
+    void noHandlerFound() {
+        ResponseEntity<ApiResponse<Void>> response = handler.handleNotFound(
+                new NoHandlerFoundException("GET", "/api/v1/no-such-endpoint", null)
+        );
+
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(404);
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.ENDPOINT_NOT_FOUND.getCode());
     }
 }


### PR DESCRIPTION
## Summary
- Spring Boot 3.2+에서 없는 경로 호출 시 발생하는 `NoResourceFoundException`을 `404 / 1003`으로 처리 (기존엔 공통 `Exception` 핸들러가 `500 / 1004`로 삼킴)
- 허용되지 않은 HTTP 메서드는 `405 / 1005` 유지
- 응답 봉투의 `status` 필드를 HTTP 상태 코드와 일치

Closes #97

## Test plan
- [ ] `GET /api/v1/no-such-endpoint` → HTTP 404, body `status:404`, `code:1003`
- [ ] `DELETE /api/v1/auth/login` → HTTP 405, body `status:405`, `code:1005`
- [ ] `GET /api/v1/auth/login` → HTTP 405, body `status:405`, `code:1005`
- [ ] `PUT /api/v1/auth/reissue` → HTTP 405, body `status:405`, `code:1005`
- [ ] 비즈니스 오류(필수 필드 누락 400, 미인증 401)는 기존과 동일
- [ ] `./gradlew test --tests GlobalExceptionHandlerTest`


Made with [Cursor](https://cursor.com)