### PR TITLE
fix: 소셜 계정 이메일 로그인 오류 코드를 1702로 교체 (#102)

### DIFF
--- a/src/main/java/com/afternote/domain/auth/service/AuthService.java
+++ b/src/main/java/com/afternote/domain/auth/service/AuthService.java
@@ -61,7 +61,7 @@ public class AuthService {
 
         // 소셜 로그인 사용자는 일반 로그인 불가
         if (user.getPassword() == null) {
-            throw new CustomException(ErrorCode.SOCIAL_CREDENTIALS_REQUIRED);
+            throw new CustomException(ErrorCode.SOCIAL_LOGIN_USER);
         }
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {

--- a/src/test/java/com/afternote/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/afternote/domain/auth/service/AuthServiceTest.java
@@ -143,7 +143,7 @@ class AuthServiceTest {
 
         assertThatThrownBy(() -> authService.login(request))
                 .isInstanceOf(CustomException.class)
-                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.SOCIAL_CREDENTIALS_REQUIRED));
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.SOCIAL_LOGIN_USER));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `AuthService.login()`에서 소셜 가입 계정(비밀번호 없음)에 대해 `SOCIAL_CREDENTIALS_REQUIRED(1603)` 대신 `SOCIAL_LOGIN_USER(1702)`를 반환
- 로그인 화면에 애프터노트 credentials 안내가 노출되던 문제 수정

Closes #102

## Test plan
- [ ] 카카오/구글로만 가입한 계정으로 이메일+비밀번호 로그인 시도
- [ ] 응답: HTTP 400, `code: 1702`, message: `소셜 로그인으로 가입한 계정입니다. 소셜 로그인을 이용해주세요.`
- [ ] 일반 이메일 가입 계정 로그인은 기존과 동일
- [ ] 애프터노트 SOCIAL 생성 시 credentials 누락은 여전히 `1603`
- [ ] `./gradlew test --tests AuthServiceTest.login_SocialUser_Fail`


Made with [Cursor](https://cursor.com)