### PR TITLE
fix: 데일리질문 등 수신자 재설정 시 중복 ID 500 수정 (#99)

### DIFF
--- a/src/main/java/com/afternote/domain/receiver/repository/DeepThoughtReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/DeepThoughtReceiverRepository.java
@@ -23,7 +23,9 @@ public interface DeepThoughtReceiverRepository extends JpaRepository<DeepThought
     """)
     List<DeepThoughtReceiver> findByDeepThoughtIdIn(@Param("deepThoughtIds") List<Long> deepThoughtIds);
 
-    void deleteByDeepThoughtId(Long deepThoughtId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM DeepThoughtReceiver dtr WHERE dtr.deepThought.id = :deepThoughtId")
+    void deleteByDeepThoughtId(@Param("deepThoughtId") Long deepThoughtId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM DeepThoughtReceiver dtr WHERE dtr.deepThought.id IN :deepThoughtIds")

--- a/src/main/java/com/afternote/domain/receiver/repository/DiaryReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/DiaryReceiverRepository.java
@@ -22,7 +22,9 @@ public interface DiaryReceiverRepository extends JpaRepository<DiaryReceiver, Lo
     """)
     List<DiaryReceiver> findByDiaryIdIn(@Param("diaryIds") List<Long> diaryIds);
 
-    void deleteByDiaryId(Long diaryId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM DiaryReceiver dr WHERE dr.diary.id = :diaryId")
+    void deleteByDiaryId(@Param("diaryId") Long diaryId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM DiaryReceiver dr WHERE dr.diary.id IN :diaryIds")

--- a/src/main/java/com/afternote/domain/receiver/repository/UserDailyQuestionReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/UserDailyQuestionReceiverRepository.java
@@ -24,7 +24,9 @@ public interface UserDailyQuestionReceiverRepository extends JpaRepository<UserD
             @Param("userDailyQuestionIds") List<Long> userDailyQuestionIds
     );
 
-    void deleteByUserDailyQuestionId(Long userDailyQuestionId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM UserDailyQuestionReceiver udqr WHERE udqr.userDailyQuestion.id = :userDailyQuestionId")
+    void deleteByUserDailyQuestionId(@Param("userDailyQuestionId") Long userDailyQuestionId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM UserDailyQuestionReceiver udqr WHERE udqr.userDailyQuestion.id IN :ids")

--- a/src/test/java/com/afternote/domain/receiver/service/MindRecordReceiverServiceTest.java
+++ b/src/test/java/com/afternote/domain/receiver/service/MindRecordReceiverServiceTest.java
@@ -1,0 +1,70 @@
+package com.afternote.domain.receiver.service;
+
+import com.afternote.domain.dailyquestion.model.UserDailyQuestion;
+import com.afternote.domain.diary.model.Diary;
+import com.afternote.domain.receiver.model.Receiver;
+import com.afternote.domain.receiver.repository.DeepThoughtReceiverRepository;
+import com.afternote.domain.receiver.repository.DiaryReceiverRepository;
+import com.afternote.domain.receiver.repository.ReceiverRepository;
+import com.afternote.domain.receiver.repository.UserDailyQuestionReceiverRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class MindRecordReceiverServiceTest {
+
+    @InjectMocks
+    private MindRecordReceiverService mindRecordReceiverService;
+
+    @Mock private ReceiverRepository receiverRepository;
+    @Mock private DiaryReceiverRepository diaryReceiverRepository;
+    @Mock private DeepThoughtReceiverRepository deepThoughtReceiverRepository;
+    @Mock private UserDailyQuestionReceiverRepository userDailyQuestionReceiverRepository;
+
+    @Test
+    @DisplayName("데일리질문 수신자 교체 시 기존 연결 삭제 후 저장")
+    void replaceUserDailyQuestionReceivers_DeletesBeforeSave() {
+        UserDailyQuestion question = mock(UserDailyQuestion.class);
+        given(question.getId()).willReturn(24L);
+
+        Receiver receiver = Receiver.builder().name("kim").relation("아들").userId(18L).build();
+        ReflectionTestUtils.setField(receiver, "id", 7L);
+        given(receiverRepository.findAllById(List.of(7L))).willReturn(List.of(receiver));
+
+        mindRecordReceiverService.replaceUserDailyQuestionReceivers(18L, question, List.of(7L), false);
+
+        InOrder inOrder = inOrder(userDailyQuestionReceiverRepository);
+        inOrder.verify(userDailyQuestionReceiverRepository).deleteByUserDailyQuestionId(24L);
+        inOrder.verify(userDailyQuestionReceiverRepository).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("일기 수신자 교체 시 기존 연결 삭제 후 저장")
+    void replaceDiaryReceivers_DeletesBeforeSave() {
+        Diary diary = mock(Diary.class);
+        given(diary.getId()).willReturn(10L);
+
+        Receiver receiver = Receiver.builder().name("kim").relation("아들").userId(18L).build();
+        ReflectionTestUtils.setField(receiver, "id", 7L);
+        given(receiverRepository.findAllById(List.of(7L))).willReturn(List.of(receiver));
+
+        mindRecordReceiverService.replaceDiaryReceivers(18L, diary, List.of(7L), false);
+
+        InOrder inOrder = inOrder(diaryReceiverRepository);
+        inOrder.verify(diaryReceiverRepository).deleteByDiaryId(10L);
+        inOrder.verify(diaryReceiverRepository).saveAll(anyList());
+    }
+}


### PR DESCRIPTION
## Summary
- `receiverIds`에 이미 연결된 수신자를 다시 보내면 유니크 제약 충돌로 `500 / 1004`가 나던 문제 수정
- 원인: `deleteBy*` 후 같은 키로 `saveAll` 할 때 DELETE가 flush되기 전에 INSERT가 실행됨
- `UserDailyQuestionReceiver` / `DiaryReceiver` / `DeepThoughtReceiver`의 단일 ID delete를 `@Modifying(flushAutomatically, clearAutomatically)` bulk delete로 통일
- 일기·깊은생각 PATCH도 동일 패턴이라 함께 수정

Closes #99

## Test plan
- [ ] 데일리질문: 수신자 7이 연결된 상태에서 `PATCH` body `{"receiverIds":[7]}` → `200`
- [ ] 데일리질문: `{"receiverIds":[7,18]}` (일부 기존·일부 신규) → `200`, 최종 연결이 요청과 동일
- [ ] 데일리질문: `{"receiverIds":[]}` → `200`, 연결 제거
- [ ] 데일리질문: `receiverIds` 없이 content만 수정 → `200`, 수신자 유지
- [ ] 일기 PATCH에도 동일 시나리오 확인
- [ ] `./gradlew test --tests MindRecordReceiverServiceTest`


Made with [Cursor](https://cursor.com)