### PR TITLE
fix: 애프터노트 생성 시 receivers·actions 선택 허용 (#100)

### DIFF
--- a/src/main/java/com/afternote/domain/afternote/dto/AfternoteCreateRequest.java
+++ b/src/main/java/com/afternote/domain/afternote/dto/AfternoteCreateRequest.java
@@ -20,20 +20,20 @@ public record AfternoteCreateRequest(
         @Getter
         String title,
 
-        @Schema(description = "체크리스트 (SOCIAL/GALLERY 전용)")
+        @Schema(description = "체크리스트 (선택, SOCIAL/GALLERY 전용). 생략 또는 빈 배열 가능")
         @Getter
         List<String> actions,
 
-        @Schema(description = "남기실 말씀 블록 목록 (제목+본문). 모든 카테고리에서 사용 가능")
+        @Schema(description = "남기실 말씀 블록 목록 (선택, 모든 카테고리). 생략 가능")
         @Getter
         @Valid
         List<LeaveMessageBlock> leaveMessage,
 
-        @Schema(description = "계정 정보 (SOCIAL 전용)")
+        @Schema(description = "계정 정보 (SOCIAL 전용, 생성 시 필수)")
         @Getter
         CredentialsRequest credentials,
 
-        @Schema(description = "수신자 목록 (선택사항, 모든 카테고리에서 가능)")
+        @Schema(description = "수신자 목록 (선택, 모든 카테고리). 생략 또는 빈 배열 가능. 포함 시 각 receiverId 필수")
         @Getter
         List<ReceiverRequest> receivers,
 

--- a/src/main/java/com/afternote/domain/afternote/service/validation/GalleryValidationStrategy.java
+++ b/src/main/java/com/afternote/domain/afternote/service/validation/GalleryValidationStrategy.java
@@ -23,11 +23,8 @@ public class GalleryValidationStrategy implements AfternoteCategoryValidationStr
             throw new CustomException(ErrorCode.INVALID_FIELD_FOR_GALLERY);
         }
 
-        if (request.getActions() == null || request.getActions().isEmpty()) {
-            throw new CustomException(ErrorCode.ACTIONS_REQUIRED);
-        }
-
-        AfternoteValidationCommons.validateRequiredReceivers(request);
+        // actions·receivers 는 선택 (없으면 빈 상태로 생성)
+        AfternoteValidationCommons.validateOptionalReceivers(request);
     }
 
     @Override

--- a/src/main/java/com/afternote/domain/afternote/service/validation/PlaylistValidationStrategy.java
+++ b/src/main/java/com/afternote/domain/afternote/service/validation/PlaylistValidationStrategy.java
@@ -38,7 +38,8 @@ public class PlaylistValidationStrategy implements AfternoteCategoryValidationSt
             }
         }
 
-        AfternoteValidationCommons.validateRequiredReceivers(request);
+        // receivers 는 선택 (없으면 빈 상태로 생성)
+        AfternoteValidationCommons.validateOptionalReceivers(request);
     }
 
     @Override

--- a/src/main/java/com/afternote/domain/afternote/service/validation/SocialValidationStrategy.java
+++ b/src/main/java/com/afternote/domain/afternote/service/validation/SocialValidationStrategy.java
@@ -20,9 +20,7 @@ public class SocialValidationStrategy implements AfternoteCategoryValidationStra
             throw new CustomException(ErrorCode.INVALID_FIELD_FOR_SOCIAL);
         }
 
-        if (request.getActions() == null || request.getActions().isEmpty()) {
-            throw new CustomException(ErrorCode.ACTIONS_REQUIRED);
-        }
+        // actions·receivers 는 선택 (없으면 빈 상태로 생성)
         if (request.getCredentials() == null) {
             throw new CustomException(ErrorCode.SOCIAL_CREDENTIALS_REQUIRED);
         }
@@ -33,7 +31,7 @@ public class SocialValidationStrategy implements AfternoteCategoryValidationStra
             throw new CustomException(ErrorCode.SOCIAL_ACCOUNT_PASSWORD_REQUIRED);
         }
 
-        AfternoteValidationCommons.validateRequiredReceivers(request);
+        AfternoteValidationCommons.validateOptionalReceivers(request);
     }
 
     @Override

--- a/src/test/java/com/afternote/domain/afternote/service/validation/AfternoteCreateValidationStrategyTest.java
+++ b/src/test/java/com/afternote/domain/afternote/service/validation/AfternoteCreateValidationStrategyTest.java
@@ -1,0 +1,70 @@
+package com.afternote.domain.afternote.service.validation;
+
+import com.afternote.domain.afternote.dto.AfternoteCreateRequest;
+import com.afternote.domain.afternote.model.AfternoteCategoryType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class AfternoteCreateValidationStrategyTest {
+
+    private final SocialValidationStrategy social = new SocialValidationStrategy();
+    private final GalleryValidationStrategy gallery = new GalleryValidationStrategy();
+    private final PlaylistValidationStrategy playlist = new PlaylistValidationStrategy();
+
+    @Test
+    @DisplayName("SOCIAL 생성 - receivers·actions 없어도 성공")
+    void social_WithoutReceiversAndActions_Ok() {
+        AfternoteCreateRequest request = new AfternoteCreateRequest(
+                AfternoteCategoryType.SOCIAL,
+                "인스타그램",
+                null,
+                null,
+                new AfternoteCreateRequest.CredentialsRequest("id", "pw"),
+                null,
+                null
+        );
+
+        assertThatCode(() -> social.validateCreate(request)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("GALLERY 생성 - receivers·actions 없어도 성공")
+    void gallery_WithoutReceiversAndActions_Ok() {
+        AfternoteCreateRequest request = new AfternoteCreateRequest(
+                AfternoteCategoryType.GALLERY,
+                "갤러리",
+                null,
+                null,
+                null,
+                List.of(),
+                null
+        );
+
+        assertThatCode(() -> gallery.validateCreate(request)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("PLAYLIST 생성 - receivers 없어도 성공")
+    void playlist_WithoutReceivers_Ok() {
+        AfternoteCreateRequest request = new AfternoteCreateRequest(
+                AfternoteCategoryType.PLAYLIST,
+                "추억 노트",
+                null,
+                null,
+                null,
+                null,
+                new AfternoteCreateRequest.PlaylistRequest(
+                        null,
+                        null,
+                        List.of(new AfternoteCreateRequest.SongRequest("곡", "가수", null)),
+                        null
+                )
+        );
+
+        assertThatCode(() -> playlist.validateCreate(request)).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Summary
- #100 이슈: 문서의 \"선택사항\"과 달리 생성 시 `receivers`/`actions`가 필수였던 문제를, **문서 정정이 아니라 동작 완화**로 해결
- `POST /api/v1/afternotes` 생성 시
  - `receivers`: 전 카테고리 선택 (생략·빈 배열 가능)
  - `actions`: SOCIAL/GALLERY 선택 (생략·빈 배열 가능)
- SOCIAL `credentials`, PLAYLIST `playlist/songs` 등 카테고리 고유 필수는 유지
- OpenAPI description도 선택 필드에 맞게 수정

Closes #100

## Test plan
- [ ] SOCIAL: `category`+`title`+`credentials`만으로 생성 → 200 (receivers/actions 없음)
- [ ] GALLERY: `category`+`title`만으로 생성 → 200
- [ ] PLAYLIST: `category`+`title`+`playlist.songs`만으로 생성 → 200
- [ ] receivers에 `receiverId` null 포함 시 → 기존처럼 400
- [ ] SOCIAL credentials 누락 시 → 여전히 400 / 1603
- [ ] `./gradlew test --tests AfternoteCreateValidationStrategyTest --tests AfternoteServiceTest`


Made with [Cursor](https://cursor.com)