### PR TITLE
fix: #139 감정 PENDING 실패 · #140 주간 요약 캐시 미스

### DIFF
--- a/deploy/sql/20260809_emotions_category_nullable.sql
+++ b/deploy/sql/20260809_emotions_category_nullable.sql
@@ -1,0 +1,3 @@
+-- #139: PENDING 감정 행 생성을 위해 emotion_category NULL 허용
+-- Hibernate ddl-auto=update 는 NOT NULL → NULL 변경을 하지 않음
+ALTER TABLE emotions MODIFY COLUMN emotion_category VARCHAR(30) NULL;

--- a/src/main/java/com/afternote/domain/dailyquestion/repository/UserDailyQuestionRepository.java
+++ b/src/main/java/com/afternote/domain/dailyquestion/repository/UserDailyQuestionRepository.java
@@ -1,6 +1,7 @@
 package com.afternote.domain.dailyquestion.repository;
 
 import com.afternote.domain.dailyquestion.model.UserDailyQuestion;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,4 +26,15 @@ public interface UserDailyQuestionRepository extends JpaRepository<UserDailyQues
             LocalDate fromInclusive,
             LocalDate toInclusive
     );
+
+    /** 감정 행이 없는 최종 답변 (userId, userDailyQuestionId). 백필용. */
+    @Query(value = """
+            SELECT q.user_id, q.id
+            FROM user_daily_question q
+            LEFT JOIN emotions e
+              ON e.user_id = q.user_id AND e.source_type = 'DAILY_QUESTION' AND e.source_id = q.id
+            WHERE q.is_draft = 0 AND q.is_answered = 1 AND e.id IS NULL
+            ORDER BY q.id ASC
+            """, nativeQuery = true)
+    List<Object[]> findFinalAnswersMissingEmotion(Pageable pageable);
 }

--- a/src/main/java/com/afternote/domain/deepthought/repository/DeepThoughtRepository.java
+++ b/src/main/java/com/afternote/domain/deepthought/repository/DeepThoughtRepository.java
@@ -2,6 +2,7 @@ package com.afternote.domain.deepthought.repository;
 
 import com.afternote.domain.deepthought.dto.DeepThoughtTagCountResponse;
 import com.afternote.domain.deepthought.model.DeepThought;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -73,4 +74,15 @@ public interface DeepThoughtRepository extends JpaRepository<DeepThought, Long> 
             LocalDateTime startInclusive,
             LocalDateTime endExclusive
     );
+
+    /** 감정 행이 없는 최종 깊은생각 (userId, deepThoughtId). 백필용. */
+    @Query(value = """
+            SELECT dt.user_id, dt.id
+            FROM deep_thought dt
+            LEFT JOIN emotions e
+              ON e.user_id = dt.user_id AND e.source_type = 'DEEP_THOUGHT' AND e.source_id = dt.id
+            WHERE dt.is_draft = 0 AND e.id IS NULL
+            ORDER BY dt.id ASC
+            """, nativeQuery = true)
+    List<Object[]> findFinalDeepThoughtsMissingEmotion(Pageable pageable);
 }

--- a/src/main/java/com/afternote/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/afternote/domain/diary/repository/DiaryRepository.java
@@ -2,6 +2,7 @@ package com.afternote.domain.diary.repository;
 
 import com.afternote.domain.diary.model.Diary;
 import com.afternote.domain.diary.model.TodayMood;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -50,4 +51,15 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 			@Param("startInclusive") LocalDateTime startInclusive,
 			@Param("endExclusive") LocalDateTime endExclusive
 	);
+
+	/** 감정 행이 없는 최종 일기 (userId, diaryId). 백필용. */
+	@Query(value = """
+			SELECT d.user_id, d.id
+			FROM diary d
+			LEFT JOIN emotions e
+			  ON e.user_id = d.user_id AND e.source_type = 'DIARY' AND e.source_id = d.id
+			WHERE d.is_draft = 0 AND e.id IS NULL
+			ORDER BY d.id ASC
+			""", nativeQuery = true)
+	List<Object[]> findFinalDiariesMissingEmotion(Pageable pageable);
 }

--- a/src/main/java/com/afternote/domain/mindrecord/emotion/config/EmotionSchemaInitializer.java
+++ b/src/main/java/com/afternote/domain/mindrecord/emotion/config/EmotionSchemaInitializer.java
@@ -1,0 +1,48 @@
+package com.afternote.domain.mindrecord.emotion.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * emotions.emotion_category 가 레거시 NOT NULL 이면 PENDING insert 가 실패한다 (#139).
+ * ddl-auto=update 로는 nullable 전환이 안 되므로 기동 시 보정한다.
+ */
+@Slf4j
+@Component
+@Order(50)
+@RequiredArgsConstructor
+public class EmotionSchemaInitializer implements ApplicationRunner {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            String nullable = jdbcTemplate.query(
+                    """
+                            SELECT IS_NULLABLE FROM information_schema.COLUMNS
+                            WHERE TABLE_SCHEMA = DATABASE()
+                              AND TABLE_NAME = 'emotions'
+                              AND COLUMN_NAME = 'emotion_category'
+                            """,
+                    rs -> rs.next() ? rs.getString(1) : null
+            );
+            if (nullable == null) {
+                log.warn("[EmotionSchema] emotions.emotion_category column not found");
+                return;
+            }
+            if ("YES".equalsIgnoreCase(nullable)) {
+                return;
+            }
+            jdbcTemplate.execute("ALTER TABLE emotions MODIFY COLUMN emotion_category VARCHAR(30) NULL");
+            log.info("[EmotionSchema] altered emotions.emotion_category to NULL");
+        } catch (Exception e) {
+            log.error("[EmotionSchema] failed to ensure emotion_category nullable", e);
+        }
+    }
+}

--- a/src/main/java/com/afternote/domain/mindrecord/emotion/model/Emotion.java
+++ b/src/main/java/com/afternote/domain/mindrecord/emotion/model/Emotion.java
@@ -33,8 +33,8 @@ public class Emotion {
     @Column(name = "source_id", nullable = false)
     private Long sourceId;
 
-    /** 분석 성공 시에만 채워진다. PENDING/FAILED 는 null. */
-    @Column(length = 30)
+    /** 분석 성공 시에만 채워진다. PENDING/FAILED 는 null. (기존 NOT NULL 컬럼은 배포 SQL로 NULL 허용 필요) */
+    @Column(name = "emotion_category", length = 30, nullable = true)
     private String emotionCategory;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/afternote/domain/mindrecord/emotion/service/EmotionAnalysisBackfillScheduler.java
+++ b/src/main/java/com/afternote/domain/mindrecord/emotion/service/EmotionAnalysisBackfillScheduler.java
@@ -1,17 +1,23 @@
 package com.afternote.domain.mindrecord.emotion.service;
 
+import com.afternote.domain.dailyquestion.repository.UserDailyQuestionRepository;
+import com.afternote.domain.deepthought.repository.DeepThoughtRepository;
+import com.afternote.domain.diary.repository.DiaryRepository;
 import com.afternote.domain.mindrecord.emotion.event.EmotionAnalysisRunner;
+import com.afternote.domain.mindrecord.emotion.model.EmotionSourceType;
 import com.afternote.domain.mindrecord.emotion.service.EmotionService.RetryCandidate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Gemini 일시 실패로 PENDING에 남은 감정 분석을 주기적으로 재시도한다.
+ * Gemini 일시 실패로 PENDING에 남은 감정 분석과, 감정 행 자체가 없는 누락분을 주기적으로 재시도한다.
  */
 @Slf4j
 @Component
@@ -20,20 +26,64 @@ public class EmotionAnalysisBackfillScheduler {
 
     private final EmotionService emotionService;
     private final EmotionAnalysisRunner emotionAnalysisRunner;
+    private final DiaryRepository diaryRepository;
+    private final UserDailyQuestionRepository userDailyQuestionRepository;
+    private final DeepThoughtRepository deepThoughtRepository;
 
     @Value("${afternote.emotion-analysis.backfill-batch-size:20}")
     private int batchSize = 20;
 
     @Scheduled(fixedDelayString = "${afternote.emotion-analysis.backfill-delay-ms:300000}")
     public void backfill() {
-        List<RetryCandidate> candidates = emotionService.findRetryCandidates(batchSize);
+        List<RetryCandidate> candidates = new ArrayList<>(emotionService.findRetryCandidates(batchSize));
+        int remaining = Math.max(0, batchSize - candidates.size());
+        if (remaining > 0) {
+            candidates.addAll(findMissingEmotionSources(remaining));
+        }
         if (candidates.isEmpty()) {
             return;
         }
-        log.info("[EmotionBackfill] retrying {} pending analyses", candidates.size());
+        log.info("[EmotionBackfill] retrying {} pending/missing analyses", candidates.size());
         for (RetryCandidate candidate : candidates) {
             dispatch(candidate);
         }
+    }
+
+    private List<RetryCandidate> findMissingEmotionSources(int limit) {
+        List<RetryCandidate> missing = new ArrayList<>();
+        PageRequest page = PageRequest.of(0, limit);
+        for (Object[] row : diaryRepository.findFinalDiariesMissingEmotion(page)) {
+            missing.add(new RetryCandidate(toLong(row[0]), EmotionSourceType.DIARY, toLong(row[1])));
+            if (missing.size() >= limit) {
+                return missing;
+            }
+        }
+        int left = limit - missing.size();
+        if (left > 0) {
+            for (Object[] row : userDailyQuestionRepository.findFinalAnswersMissingEmotion(PageRequest.of(0, left))) {
+                missing.add(new RetryCandidate(toLong(row[0]), EmotionSourceType.DAILY_QUESTION, toLong(row[1])));
+                if (missing.size() >= limit) {
+                    return missing;
+                }
+            }
+        }
+        left = limit - missing.size();
+        if (left > 0) {
+            for (Object[] row : deepThoughtRepository.findFinalDeepThoughtsMissingEmotion(PageRequest.of(0, left))) {
+                missing.add(new RetryCandidate(toLong(row[0]), EmotionSourceType.DEEP_THOUGHT, toLong(row[1])));
+                if (missing.size() >= limit) {
+                    return missing;
+                }
+            }
+        }
+        return missing;
+    }
+
+    private static Long toLong(Object value) {
+        if (value instanceof Number n) {
+            return n.longValue();
+        }
+        return Long.valueOf(String.valueOf(value));
     }
 
     private void dispatch(RetryCandidate candidate) {

--- a/src/main/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordService.java
+++ b/src/main/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordService.java
@@ -23,6 +23,7 @@ import com.afternote.global.exception.CustomException;
 import com.afternote.global.exception.ErrorCode;
 import com.afternote.global.service.GeminiService;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -155,9 +156,9 @@ public class WeeklyMindRecordService {
                         weeklyReportRepository.findByUserIdAndStartDate(user.getId(), storedStart);
 
                 if (existing.isPresent()
-                        && Objects.equals(existing.get().getKeywordJson(), keywordJson)
+                        && sameKeywordJson(existing.get().getKeywordJson(), keywordJson)
                         && isUsableSummary(existing.get().getSummaryText())) {
-                    log.debug("[WeeklySummary] cache_hit userId={} week={}", user.getId(), weekMonday);
+                    log.info("[WeeklySummary] cache_hit userId={} week={}", user.getId(), weekMonday);
                     return existing.get().getSummaryText();
                 }
 
@@ -193,6 +194,27 @@ public class WeeklyMindRecordService {
 
     private static boolean isUsableSummary(String summaryText) {
         return summaryText != null && !summaryText.isBlank() && !isFallbackSummary(summaryText);
+    }
+
+    /**
+     * MySQL json 컬럼은 저장 시 공백/키 순서를 정규화하므로, 문자열 equals로는 캐시가 항상 미스난다.
+     * 파싱한 JsonNode로 구조 동등성을 비교한다.
+     */
+    private boolean sameKeywordJson(String stored, String current) {
+        if (Objects.equals(stored, current)) {
+            return true;
+        }
+        if (stored == null || current == null || stored.isBlank() || current.isBlank()) {
+            return false;
+        }
+        try {
+            JsonNode a = objectMapper.readTree(stored);
+            JsonNode b = objectMapper.readTree(current);
+            return a.equals(b);
+        } catch (JsonProcessingException e) {
+            log.warn("[WeeklySummary] keywordJson parse failed stored={} current={}", stored, current);
+            return false;
+        }
     }
 
     private void persistWeeklyReport(

--- a/src/test/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordServiceSummaryTest.java
+++ b/src/test/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordServiceSummaryTest.java
@@ -91,6 +91,21 @@ class WeeklyMindRecordServiceSummaryTest {
         verify(geminiService, never()).generateWeeklyMindRecordSummary(anyString());
     }
 
+    @Test
+    @DisplayName("MySQL json 공백 정규화와 Jackson compact 직렬화가 달라도 동일로 본다")
+    void sameKeywordJson_ignoresMysqlSpacing() {
+        ReflectionTestUtils.setField(weeklyMindRecordService, "objectMapper", new ObjectMapper());
+
+        Boolean same = ReflectionTestUtils.invokeMethod(
+                weeklyMindRecordService,
+                "sameKeywordJson",
+                "[{\"keyword\": \"평온\", \"percentage\": 100}]",
+                "[{\"keyword\":\"평온\",\"percentage\":100}]"
+        );
+
+        assertThat(same).isTrue();
+    }
+
     private static User sampleUser(Long id) {
         User user = User.builder()
                 .email("u@test.com")


### PR DESCRIPTION
## Summary
- **#139**: `emotions.emotion_category` NOT NULL 때문에 PENDING insert가 실패하던 문제를 기동 시/배포 SQL로 NULL 허용하고, 감정 행 자체가 없는 누락분도 백필 대상으로 포함한다.
- **#140**: MySQL `json` 컬럼의 공백 정규화와 Jackson compact 직렬화 불일치로 캐시가 항상 miss 나던 문제를 JsonNode 구조 비교로 고친다.
- 배포 SQL: `deploy/sql/20260809_emotions_category_nullable.sql` (프로덕션에는 이미 ALTER 적용됨)

Fixes #139
Fixes #140

## Test plan
- [ ] 최종 일기 저장 후 `emotionAnalysis`가 수분 내 `succeeded` 또는 `failed`로 종결되는지 확인
- [ ] 감정 행이 없던 과거 최종 기록도 백필로 분석이 도는지 확인
- [ ] 동일 주차·동일 emotions로 주간 마음기록 GET 연속 조회 시 2회차부터 Gemini 없이 캐시 히트(`cache_hit` 로그)되는지 확인
- [ ] `WeeklyMindRecordServiceSummaryTest` 통과


Made with [Cursor](https://cursor.com)