### PR TITLE
fix: #120 SOCIAL 1616 · #123 OpenAPI · #137 lastActiveAt

### DIFF
--- a/src/main/java/com/afternote/domain/afternote/controller/AfternoteController.java
+++ b/src/main/java/com/afternote/domain/afternote/controller/AfternoteController.java
@@ -10,6 +10,7 @@ import com.afternote.global.common.ApiResponse;
 import com.afternote.global.resolver.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -57,6 +58,11 @@ public class AfternoteController {
             summary = "애프터노트 상세 목록 조회 API",
             description = "애프터노트 상세목록을 가져옵니다. path variable로 afternote_id를 보내주시면 됩니다."
     )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "애프터노트 상세 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청 (code: 1000)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "애프터노트를 찾을 수 없음 (code: 1600)")
+    })
     @GetMapping("/{afternoteId}")
     public ApiResponse<AfternotedetailResponse> getDetailAfternote(
             @Parameter(hidden = true) @UserId Long userId,

--- a/src/main/java/com/afternote/domain/afternote/service/validation/SocialValidationStrategy.java
+++ b/src/main/java/com/afternote/domain/afternote/service/validation/SocialValidationStrategy.java
@@ -36,12 +36,11 @@ public class SocialValidationStrategy implements AfternoteCategoryValidationStra
 
     @Override
     public void validateUpdate(AfternoteCreateRequest request) {
-        if (request.getReceivers() != null && !request.getReceivers().isEmpty()) {
-            throw new CustomException(ErrorCode.INVALID_FIELD_FOR_SOCIAL);
-        }
         if (request.getPlaylist() != null) {
             throw new CustomException(ErrorCode.INVALID_FIELD_FOR_SOCIAL);
         }
+        // receivers·credentials·title·actions·leaveMessage 는 수정 허용
+        AfternoteValidationCommons.validateOptionalReceivers(request);
     }
 
 }

--- a/src/main/java/com/afternote/domain/appversion/controller/AppVersionController.java
+++ b/src/main/java/com/afternote/domain/appversion/controller/AppVersionController.java
@@ -6,6 +6,7 @@ import com.afternote.domain.appversion.service.AppVersionService;
 import com.afternote.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,7 @@ public class AppVersionController {
                     - API 호출 실패 또는 `updateRequired=true`이면 클라이언트에서 스플래시 진입을 막습니다.
                     """
     )
+    @SecurityRequirements // 전역 bearer 상속 제거 → OpenAPI security: []
     @GetMapping
     public ApiResponse<AppVersionCheckResponse> checkVersion(
             @Parameter(description = "플랫폼", example = "ANDROID", required = true)

--- a/src/main/java/com/afternote/domain/appversion/dto/AppVersionCheckResponse.java
+++ b/src/main/java/com/afternote/domain/appversion/dto/AppVersionCheckResponse.java
@@ -13,7 +13,11 @@ public record AppVersionCheckResponse(
         @Getter
         int latestVersionCode,
 
-        @Schema(description = "Play Store URL (updateRequired=true일 때만 포함)", example = "https://play.google.com/store/apps/details?id=com.afternote")
+        @Schema(
+                description = "Play Store URL. updateRequired=true일 때 스토어 URL, 불필요하면 null",
+                example = "https://play.google.com/store/apps/details?id=com.afternote",
+                nullable = true
+        )
         @Getter
         String storeUrl
 ) {

--- a/src/main/java/com/afternote/domain/auth/service/AuthService.java
+++ b/src/main/java/com/afternote/domain/auth/service/AuthService.java
@@ -54,7 +54,7 @@ public class AuthService {
         return userRepository.save(user);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public LoginResponse login(LoginRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -67,6 +67,8 @@ public class AuthService {
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
         }
+
+        user.touchActivity();
 
         String accessToken = jwtTokenProvider.generateAccessToken(user.getId());
         String refreshToken = jwtTokenProvider.generateRefreshToken(user.getId());
@@ -97,8 +99,11 @@ public class AuthService {
         if (storedUserId == null || !storedUserId.equals(userId)) {
             throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
+
+        // 4. 로그인 상태 확정을 활동으로 집계 (클라이언트 ping 의존 제거)
+        userRepository.findById(userId).ifPresent(User::touchActivity);
         
-        // 4. 신규 토큰 발급 (RTR 전략)
+        // 5. 신규 토큰 발급 (RTR 전략)
         String newAccessToken = jwtTokenProvider.generateAccessToken(userId);
         String newRefreshToken = jwtTokenProvider.generateRefreshToken(userId);
         tokenService.saveToken(newRefreshToken, userId);

--- a/src/main/java/com/afternote/domain/music/controller/MusicController.java
+++ b/src/main/java/com/afternote/domain/music/controller/MusicController.java
@@ -4,6 +4,7 @@ import com.afternote.domain.music.dto.GetMusicSearchResponse;
 import com.afternote.domain.music.service.ItunesService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,7 +15,11 @@ public class MusicController {
 
     private final ItunesService itunesService;
 
-    @Operation(summary = "노래 검색 API", description = "가수명 또는 노래 제목으로 노래를 검색")
+    @Operation(
+            summary = "노래 검색 API",
+            description = "가수명 또는 노래 제목으로 노래를 검색. JWT 인증 없이 사용합니다."
+    )
+    @SecurityRequirements // 전역 bearer 상속 제거 → OpenAPI security: []
     @GetMapping("/search")
     public GetMusicSearchResponse searchMusic(
             @Parameter(description = "검색어", example = "아이유", required = true)

--- a/src/main/java/com/afternote/domain/user/controller/UserController.java
+++ b/src/main/java/com/afternote/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.afternote.global.common.ApiResponse;
 import com.afternote.global.resolver.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,10 @@ public class UserController {
             summary = "내 프로필 조회 API",
             description = "로그인한 사용자의 프로필 정보를 조회합니다."
     )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로필 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청 (code: 1000)")
+    })
     @GetMapping("/me")
     public ApiResponse<UserResponse> getMyProfile(
             @Parameter(hidden = true) @UserId Long userId

--- a/src/main/java/com/afternote/global/exception/ErrorCode.java
+++ b/src/main/java/com/afternote/global/exception/ErrorCode.java
@@ -145,7 +145,7 @@ public enum ErrorCode {
     ACTIONS_REQUIRED(HttpStatus.BAD_REQUEST, 1613, "액션(actions)은 최소 1개 이상 필요합니다."),
     CATEGORY_CANNOT_BE_CHANGED(HttpStatus.BAD_REQUEST, 1614, "카테고리는 변경할 수 없습니다."),
     RECEIVERS_REQUIRED(HttpStatus.BAD_REQUEST, 1615, "수신자(receivers)는 최소 1명 이상 필요합니다."),
-    INVALID_FIELD_FOR_SOCIAL(HttpStatus.BAD_REQUEST, 1616, "SOCIAL 카테고리는 credentials만 수정할 수 있습니다."),                                                                                           
+    INVALID_FIELD_FOR_SOCIAL(HttpStatus.BAD_REQUEST, 1616, "SOCIAL 카테고리에서는 playlist 필드를 사용할 수 없습니다."),                                                                                           
     INVALID_FIELD_FOR_GALLERY(HttpStatus.BAD_REQUEST, 1617, "GALLERY 카테고리는 receivers만 수정할 수 있습니다."),                                                                                           
     INVALID_FIELD_FOR_PLAYLIST(HttpStatus.BAD_REQUEST, 1618, "PLAYLIST 카테고리는 playlist만 수정할 수 있습니다."),                                                                                          
     FIELD_CANNOT_BE_EMPTY(HttpStatus.BAD_REQUEST, 1619, "필드 값은 공백일 수 없습니다."),                                                                                                                    

--- a/src/test/java/com/afternote/domain/afternote/service/validation/AfternoteCreateValidationStrategyTest.java
+++ b/src/test/java/com/afternote/domain/afternote/service/validation/AfternoteCreateValidationStrategyTest.java
@@ -2,12 +2,16 @@ package com.afternote.domain.afternote.service.validation;
 
 import com.afternote.domain.afternote.dto.AfternoteCreateRequest;
 import com.afternote.domain.afternote.model.AfternoteCategoryType;
+import com.afternote.global.exception.CustomException;
+import com.afternote.global.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AfternoteCreateValidationStrategyTest {
 
@@ -29,6 +33,82 @@ class AfternoteCreateValidationStrategyTest {
         );
 
         assertThatCode(() -> social.validateCreate(request)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("SOCIAL 생성 - playlist 포함 시 1616, playlist 필드 기준 메시지")
+    void social_CreateWithPlaylist_RejectsWithFieldMessage() {
+        AfternoteCreateRequest request = new AfternoteCreateRequest(
+                AfternoteCategoryType.SOCIAL,
+                "인스타그램",
+                null,
+                null,
+                new AfternoteCreateRequest.CredentialsRequest("id", "pw"),
+                null,
+                new AfternoteCreateRequest.PlaylistRequest(
+                        null,
+                        null,
+                        List.of(new AfternoteCreateRequest.SongRequest("곡", "가수", null)),
+                        null
+                )
+        );
+
+        assertThatThrownBy(() -> social.validateCreate(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException ce = (CustomException) ex;
+                    assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.INVALID_FIELD_FOR_SOCIAL);
+                    assertThat(ce.getErrorCode().getMessage())
+                            .contains("playlist")
+                            .doesNotContain("credentials만")
+                            .doesNotContain("수정할 수 있습니다");
+                });
+    }
+
+    @Test
+    @DisplayName("SOCIAL 수정 - receivers 포함해도 성공")
+    void social_UpdateWithReceivers_Ok() {
+        AfternoteCreateRequest request = new AfternoteCreateRequest(
+                AfternoteCategoryType.SOCIAL,
+                "인스타그램",
+                null,
+                null,
+                new AfternoteCreateRequest.CredentialsRequest("id", "pw"),
+                List.of(new AfternoteCreateRequest.ReceiverRequest(1L)),
+                null
+        );
+
+        assertThatCode(() -> social.validateUpdate(request)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("SOCIAL 수정 - playlist 포함 시 1616, 생성/수정 문맥이 섞이지 않음")
+    void social_UpdateWithPlaylist_RejectsWithoutCreateWording() {
+        AfternoteCreateRequest request = new AfternoteCreateRequest(
+                AfternoteCategoryType.SOCIAL,
+                "인스타그램",
+                null,
+                null,
+                null,
+                null,
+                new AfternoteCreateRequest.PlaylistRequest(
+                        null,
+                        null,
+                        List.of(new AfternoteCreateRequest.SongRequest("곡", "가수", null)),
+                        null
+                )
+        );
+
+        assertThatThrownBy(() -> social.validateUpdate(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException ce = (CustomException) ex;
+                    assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.INVALID_FIELD_FOR_SOCIAL);
+                    assertThat(ce.getErrorCode().getMessage())
+                            .contains("playlist")
+                            .doesNotContain("credentials만")
+                            .doesNotContain("수정할 수 있습니다");
+                });
     }
 
     @Test

--- a/src/test/java/com/afternote/domain/appversion/controller/AppVersionControllerTest.java
+++ b/src/test/java/com/afternote/domain/appversion/controller/AppVersionControllerTest.java
@@ -48,7 +48,8 @@ class AppVersionControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.updateRequired").value(false))
                 .andExpect(jsonPath("$.data.latestVersionCode").value(10001))
-                .andExpect(jsonPath("$.data.storeUrl").doesNotExist());
+                // 배포 응답과 동일: 필드가 null로 포함됨 (omit 아님)
+                .andExpect(jsonPath("$.data.storeUrl").value((Object) null));
 
         verify(appVersionService).checkVersion(AppPlatform.ANDROID, 10001);
     }

--- a/src/test/java/com/afternote/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/afternote/domain/auth/service/AuthServiceTest.java
@@ -20,14 +20,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -147,7 +148,7 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("로그인 성공")
+    @DisplayName("로그인 성공 - lastActiveAt 갱신")
     void login_Success() {
         LoginRequest request = org.mockito.Mockito.mock(LoginRequest.class);
         given(request.getEmail()).willReturn("test@test.com");
@@ -161,6 +162,8 @@ class AuthServiceTest {
                 .provider(AuthProvider.LOCAL)
                 .build();
         ReflectionTestUtils.setField(user, "id", 10L);
+        LocalDateTime beforeLogin = LocalDateTime.now().minusDays(3);
+        ReflectionTestUtils.setField(user, "lastActiveAt", beforeLogin);
 
         given(userRepository.findByEmail("test@test.com")).willReturn(Optional.of(user));
         given(passwordEncoder.matches("Password1!", "encoded")).willReturn(true);
@@ -173,30 +176,57 @@ class AuthServiceTest {
         assertThat(response.getAccessToken()).isEqualTo("access");
         assertThat(response.getRefreshToken()).isEqualTo("refresh");
         assertThat(response.getExpiresIn()).isEqualTo(3600L);
+        assertThat(user.getLastActiveAt()).isAfter(beforeLogin);
         verify(tokenService).saveToken("refresh", 10L);
     }
 
     @Test
-    @DisplayName("재발급 실패 - 유효하지 않은 리프레시 토큰")
-    void reissue_InvalidToken_Fail() {
-        ReissueRequest request = org.mockito.Mockito.mock(ReissueRequest.class);
-        given(request.getRefreshToken()).willReturn("rt");
-        given(jwtTokenProvider.validateToken("rt")).willReturn(false);
+    @DisplayName("로그인 실패 - 비밀번호 불일치 시 lastActiveAt 미갱신")
+    void login_PasswordMismatch_DoesNotTouchActivity() {
+        LoginRequest request = org.mockito.Mockito.mock(LoginRequest.class);
+        given(request.getEmail()).willReturn("test@test.com");
+        given(request.getPassword()).willReturn("wrong");
 
-        assertThatThrownBy(() -> authService.reissue(request))
+        User user = User.builder()
+                .email("test@test.com")
+                .password("encoded")
+                .name("tester")
+                .status(UserStatus.ACTIVE)
+                .provider(AuthProvider.LOCAL)
+                .build();
+        LocalDateTime before = LocalDateTime.now().minusDays(1);
+        ReflectionTestUtils.setField(user, "lastActiveAt", before);
+
+        given(userRepository.findByEmail("test@test.com")).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("wrong", "encoded")).willReturn(false);
+
+        assertThatThrownBy(() -> authService.login(request))
                 .isInstanceOf(CustomException.class)
-                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN));
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.PASSWORD_MISMATCH));
+        assertThat(user.getLastActiveAt()).isEqualTo(before);
     }
 
     @Test
-    @DisplayName("재발급 성공")
+    @DisplayName("재발급 성공 - lastActiveAt 갱신")
     void reissue_Success() {
         ReissueRequest request = org.mockito.Mockito.mock(ReissueRequest.class);
         given(request.getRefreshToken()).willReturn("oldRt");
 
+        User user = User.builder()
+                .email("test@test.com")
+                .password("encoded")
+                .name("tester")
+                .status(UserStatus.ACTIVE)
+                .provider(AuthProvider.LOCAL)
+                .build();
+        ReflectionTestUtils.setField(user, "id", 11L);
+        LocalDateTime beforeReissue = LocalDateTime.now().minusDays(2);
+        ReflectionTestUtils.setField(user, "lastActiveAt", beforeReissue);
+
         given(jwtTokenProvider.validateToken("oldRt")).willReturn(true);
         given(jwtTokenProvider.getUserId("oldRt")).willReturn(11L);
         given(tokenService.getUserIdAndDelete("oldRt")).willReturn(11L);
+        given(userRepository.findById(11L)).willReturn(Optional.of(user));
         given(jwtTokenProvider.generateAccessToken(11L)).willReturn("newAccess");
         given(jwtTokenProvider.generateRefreshToken(11L)).willReturn("newRt");
         given(jwtTokenProvider.getAccessTokenExpirationSeconds()).willReturn(3600L);
@@ -206,7 +236,22 @@ class AuthServiceTest {
         assertThat(response.getAccessToken()).isEqualTo("newAccess");
         assertThat(response.getRefreshToken()).isEqualTo("newRt");
         assertThat(response.getExpiresIn()).isEqualTo(3600L);
+        assertThat(user.getLastActiveAt()).isAfter(beforeReissue);
         verify(tokenService).saveToken("newRt", 11L);
+        verify(userRepository).findById(11L);
+    }
+
+    @Test
+    @DisplayName("재발급 실패 - 토큰 무효 시 lastActiveAt 미조회")
+    void reissue_InvalidToken_DoesNotLoadUser() {
+        ReissueRequest request = org.mockito.Mockito.mock(ReissueRequest.class);
+        given(request.getRefreshToken()).willReturn("rt");
+        given(jwtTokenProvider.validateToken("rt")).willReturn(false);
+
+        assertThatThrownBy(() -> authService.reissue(request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode()).isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN));
+        verify(userRepository, never()).findById(any());
     }
 
     @Test

--- a/src/test/java/com/afternote/global/config/OpenApiContractAnnotationTest.java
+++ b/src/test/java/com/afternote/global/config/OpenApiContractAnnotationTest.java
@@ -1,0 +1,85 @@
+package com.afternote.global.config;
+
+import com.afternote.domain.afternote.controller.AfternoteController;
+import com.afternote.domain.appversion.controller.AppVersionController;
+import com.afternote.domain.appversion.dto.AppVersionCheckResponse;
+import com.afternote.domain.music.controller.MusicController;
+import com.afternote.domain.user.controller.UserController;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #123 회귀 방지: 배포 OpenAPI와 어긋나기 쉬운 계약을 어노테이션 단위로 고정한다.
+ * (전체 /v3/api-docs 기동 없이 CI에서 빠르게 검증)
+ *
+ * 주의: {@code @Operation(security = {})} 는 springdoc가 생략해서 전역 bearer가 남는다.
+ * 공개 API는 반드시 {@code @SecurityRequirements} 로 끊는다.
+ */
+class OpenApiContractAnnotationTest {
+
+    @Test
+    @DisplayName("공개 API는 @SecurityRequirements 로 전역 Bearer 상속을 끊는다")
+    void publicApis_OverrideSecurityToEmpty() throws Exception {
+        Method checkVersion = AppVersionController.class.getDeclaredMethod(
+                "checkVersion",
+                com.afternote.domain.appversion.model.AppPlatform.class,
+                int.class
+        );
+        Method searchMusic = MusicController.class.getDeclaredMethod("searchMusic", String.class);
+
+        assertThat(checkVersion.getAnnotation(SecurityRequirements.class)).isNotNull();
+        assertThat(searchMusic.getAnnotation(SecurityRequirements.class)).isNotNull();
+        assertThat(checkVersion.getAnnotation(SecurityRequirements.class).value()).isEmpty();
+        assertThat(searchMusic.getAnnotation(SecurityRequirements.class).value()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("GET /users/me 는 401을 OpenAPI에 선언한다")
+    void usersMe_Documents401() throws Exception {
+        Method getMyProfile = UserController.class.getDeclaredMethod("getMyProfile", Long.class);
+        Set<String> codes = responseCodes(getMyProfile);
+
+        assertThat(codes).contains("200", "401");
+    }
+
+    @Test
+    @DisplayName("GET /afternotes/{id} 는 401·404를 OpenAPI에 선언한다")
+    void afternoteDetail_Documents401And404() throws Exception {
+        Method getDetail = AfternoteController.class.getDeclaredMethod(
+                "getDetailAfternote",
+                Long.class,
+                Long.class
+        );
+        Set<String> codes = responseCodes(getDetail);
+
+        assertThat(codes).contains("200", "401", "404");
+    }
+
+    @Test
+    @DisplayName("AppVersionCheckResponse.storeUrl 은 nullable=true")
+    void storeUrl_IsNullableInSchema() throws Exception {
+        // record component 헤더의 @Schema는 accessor 메서드에 붙는다
+        Schema schema = AppVersionCheckResponse.class.getDeclaredMethod("storeUrl").getAnnotation(Schema.class);
+        assertThat(schema).isNotNull();
+        assertThat(schema.nullable()).isTrue();
+    }
+
+    private static Set<String> responseCodes(Method method) {
+        ApiResponses responses = method.getAnnotation(ApiResponses.class);
+        assertThat(responses).as("@ApiResponses on %s", method.getName()).isNotNull();
+        return Arrays.stream(responses.value())
+                .map(ApiResponse::responseCode)
+                .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
## Summary
- #120: SOCIAL `playlist` 거절 메시지를 필드 기준으로 수정하고 PATCH `receivers`를 허용
- #123: 공개 API `@SecurityRequirements`, `/users/me`·애프터노트 상세 401/404 문서화, `storeUrl` nullable
- #137: login·reissue 성공 시 `lastActiveAt` 갱신

## Test plan
- [x] `AfternoteCreateValidationStrategyTest` (playlist 1616, receivers PATCH ok)
- [x] `AuthServiceTest` (login/reissue activity)
- [x] `OpenApiContractAnnotationTest` + `AppVersionControllerTest`
- [ ] 배포 후 curl로 1616 문구·OpenAPI security `[]`·reissue 후 `last_active_at` 확인

Fixes #120
Fixes #123
Fixes #137


Made with [Cursor](https://cursor.com)