### PR TITLE
fix: #141 S3 staging 누수 차단과 업로드 크기 상한

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -27,6 +27,11 @@ AWS_S3_BUCKET=
 AWS_ACCESS_KEY=
 AWS_SECRET_KEY=
 AWS_PUBLIC_BASE_URL=
+# Optional upload size caps (bytes). Defaults: image 10MB / video 200MB / audio 50MB / document 20MB
+# S3_UPLOAD_MAX_BYTES_IMAGE=
+# S3_UPLOAD_MAX_BYTES_VIDEO=
+# S3_UPLOAD_MAX_BYTES_AUDIO=
+# S3_UPLOAD_MAX_BYTES_DOCUMENT=
 
 # Mail (optional)
 EMAIL=

--- a/src/main/java/com/afternote/domain/afternote/service/relation/PlaylistRelationStrategy.java
+++ b/src/main/java/com/afternote/domain/afternote/service/relation/PlaylistRelationStrategy.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class PlaylistRelationStrategy implements AfternoteCategoryRelationStrategy {
 
     private static final String DEFAULT_PLAYLIST_TITLE = "추모 플레이리스트";
+    private static final String AFTERNOTES_DIRECTORY = "afternotes";
 
     private final AfternotePlaylistRepository playlistRepository;
     private final S3Service s3Service;
@@ -28,11 +29,12 @@ public class PlaylistRelationStrategy implements AfternoteCategoryRelationStrate
     public void save(Afternote afternote, AfternoteCreateRequest request) {
         if (request.getPlaylist() == null) return;
 
-        AfternotePlaylist.MemorialVideo memorialVideo = createMemorialVideo(request.getPlaylist().getMemorialVideo());
+        Long userId = afternote.getUser().getId();
+        AfternotePlaylist.MemorialVideo memorialVideo = createMemorialVideo(userId, request.getPlaylist().getMemorialVideo());
         AfternotePlaylist playlist = createPlaylist(
                 afternote,
                 request.getPlaylist().getAtmosphere(),
-            normalizeKey(request.getPlaylist().getMemorialPhotoUrl()),
+                promoteKey(userId, request.getPlaylist().getMemorialPhotoUrl()),
                 memorialVideo);
 
         playlist = playlistRepository.save(playlist);
@@ -40,7 +42,7 @@ public class PlaylistRelationStrategy implements AfternoteCategoryRelationStrate
         if (request.getPlaylist().getSongs() != null) {
             int sortOrder = 1;
             for (AfternoteCreateRequest.SongRequest songReq : request.getPlaylist().getSongs()) {
-                playlist.getItems().add(createPlaylistItem(playlist, songReq, sortOrder++));
+                playlist.getItems().add(createPlaylistItem(userId, playlist, songReq, sortOrder++));
             }
             playlistRepository.save(playlist);
         }
@@ -50,15 +52,16 @@ public class PlaylistRelationStrategy implements AfternoteCategoryRelationStrate
     public void update(Afternote afternote, AfternoteCreateRequest request) {
         if (request.getPlaylist() == null) return;
 
+        Long userId = afternote.getUser().getId();
         AfternotePlaylist playlist = afternote.getPlaylist();
 
         if (playlist == null) {
             AfternotePlaylist newPlaylist = createPlaylist(
                     afternote,
                     request.getPlaylist().getAtmosphere(),
-                    normalizeKey(request.getPlaylist().getMemorialPhotoUrl()),
+                    promoteKey(userId, request.getPlaylist().getMemorialPhotoUrl()),
                     request.getPlaylist().getMemorialVideo() != null
-                            ? createMemorialVideo(request.getPlaylist().getMemorialVideo())
+                            ? createMemorialVideo(userId, request.getPlaylist().getMemorialVideo())
                             : null);
 
             newPlaylist = playlistRepository.save(newPlaylist);
@@ -66,7 +69,7 @@ public class PlaylistRelationStrategy implements AfternoteCategoryRelationStrate
             if (request.getPlaylist().getSongs() != null) {
                 int sortOrder = 1;
                 for (AfternoteCreateRequest.SongRequest songReq : request.getPlaylist().getSongs()) {
-                    newPlaylist.getItems().add(createPlaylistItem(newPlaylist, songReq, sortOrder++));
+                    newPlaylist.getItems().add(createPlaylistItem(userId, newPlaylist, songReq, sortOrder++));
                 }
                 playlistRepository.save(newPlaylist);
             }
@@ -74,30 +77,30 @@ public class PlaylistRelationStrategy implements AfternoteCategoryRelationStrate
         }
 
         AfternotePlaylist.MemorialVideo memorialVideo = request.getPlaylist().getMemorialVideo() != null
-                ? createMemorialVideo(request.getPlaylist().getMemorialVideo())
+                ? createMemorialVideo(userId, request.getPlaylist().getMemorialVideo())
                 : null;
         playlist.update(
                 request.getPlaylist().getAtmosphere(),
-            normalizeKey(request.getPlaylist().getMemorialPhotoUrl()),
+                promoteKey(userId, request.getPlaylist().getMemorialPhotoUrl()),
                 memorialVideo);
 
         if (request.getPlaylist().getSongs() != null) {
             playlist.getItems().clear();
             int sortOrder = 1;
             for (AfternoteCreateRequest.SongRequest songReq : request.getPlaylist().getSongs()) {
-                playlist.getItems().add(createPlaylistItem(playlist, songReq, sortOrder++));
+                playlist.getItems().add(createPlaylistItem(userId, playlist, songReq, sortOrder++));
             }
         }
 
         playlistRepository.save(playlist);
     }
 
-    private AfternotePlaylist.MemorialVideo createMemorialVideo(AfternoteCreateRequest.MemorialVideoRequest request) {
+    private AfternotePlaylist.MemorialVideo createMemorialVideo(Long userId, AfternoteCreateRequest.MemorialVideoRequest request) {
         if (request == null) return null;
 
         return AfternotePlaylist.MemorialVideo.builder()
-            .videoUrl(normalizeKey(request.getVideoUrl()))
-            .thumbnailUrl(normalizeKey(request.getThumbnailUrl()))
+                .videoUrl(promoteKey(userId, request.getVideoUrl()))
+                .thumbnailUrl(promoteKey(userId, request.getThumbnailUrl()))
                 .build();
     }
 
@@ -117,6 +120,7 @@ public class PlaylistRelationStrategy implements AfternoteCategoryRelationStrate
     }
 
     private AfternotePlaylistItem createPlaylistItem(
+            Long userId,
             AfternotePlaylist playlist,
             AfternoteCreateRequest.SongRequest song,
             int sortOrder
@@ -125,17 +129,15 @@ public class PlaylistRelationStrategy implements AfternoteCategoryRelationStrate
                 .playlist(playlist)
                 .songTitle(song.getTitle())
                 .artist(song.getArtist())
-                .coverUrl(normalizeKey(song.getCoverUrl()))
+                .coverUrl(promoteKey(userId, song.getCoverUrl()))
                 .sortOrder(sortOrder)
                 .build();
     }
 
-    private String normalizeKey(String rawUrlOrKey) {
+    private String promoteKey(Long userId, String rawUrlOrKey) {
         if (rawUrlOrKey == null || rawUrlOrKey.isBlank()) {
             return rawUrlOrKey;
         }
-
-        String key = s3Service.extractStorageKey(rawUrlOrKey);
-        return key != null ? key : rawUrlOrKey;
+        return s3Service.promoteMediaKey(AFTERNOTES_DIRECTORY, userId, rawUrlOrKey);
     }
 }

--- a/src/main/java/com/afternote/domain/image/controller/ImageController.java
+++ b/src/main/java/com/afternote/domain/image/controller/ImageController.java
@@ -23,14 +23,24 @@ public class ImageController {
 
     private final S3Service s3Service;
 
-    @Operation(summary = "Presigned URL 생성", description = "S3 파일 업로드를 위한 Presigned URL을 생성합니다. 지원 형식: 이미지(jpg, jpeg, png, gif, webp, heic), 영상(mp4, mov), 음성(mp3, m4a, wav), 문서(pdf)")
+    @Operation(
+            summary = "Presigned URL 생성",
+            description = "S3 파일 업로드를 위한 Presigned URL을 생성합니다. "
+                    + "contentLength는 서명에 포함되므로 PUT 시 동일 Content-Length 헤더가 필요합니다. "
+                    + "지원 형식: 이미지(jpg, jpeg, png, gif, webp, heic), 영상(mp4, mov), 음성(mp3, m4a, wav), 문서(pdf)"
+    )
     @PostMapping("/presigned-url")
     public ApiResponse<PresignedUrlResponse> getPresignedUrl(
             @Parameter(hidden = true) @UserId Long userId,
             @Valid @RequestBody PresignedUrlRequest request
     ) {
         return ApiResponse.success(
-                s3Service.generatePresignedUrl(request.getDirectory(), request.getExtension(), userId)
+                s3Service.generatePresignedUrl(
+                        request.getDirectory(),
+                        request.getExtension(),
+                        request.getContentLength(),
+                        userId
+                )
         );
     }
 }

--- a/src/main/java/com/afternote/domain/image/dto/PresignedUrlRequest.java
+++ b/src/main/java/com/afternote/domain/image/dto/PresignedUrlRequest.java
@@ -2,6 +2,8 @@ package com.afternote.domain.image.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 
 public record PresignedUrlRequest(
@@ -15,6 +17,13 @@ public record PresignedUrlRequest(
             allowableValues = {"jpg", "jpeg", "png", "gif", "webp", "heic", "mp4", "mov", "mp3", "m4a", "wav", "pdf"})
         @NotBlank(message = "파일 확장자는 필수입니다.")
         @Getter
-        String extension
+        String extension,
+
+        @Schema(description = "업로드할 파일 크기(바이트). Presigned PUT 시 Content-Length 와 동일해야 합니다.",
+            example = "1048576")
+        @NotNull(message = "파일 크기는 필수입니다.")
+        @Positive(message = "파일 크기는 1바이트 이상이어야 합니다.")
+        @Getter
+        Long contentLength
 ) {
 }

--- a/src/main/java/com/afternote/domain/image/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/afternote/domain/image/dto/PresignedUrlResponse.java
@@ -24,6 +24,16 @@ public record PresignedUrlResponse(
         @Schema(description = "PUT 요청 시 사용할 Content-Type 헤더 값",
             example = "image/jpeg")
         @Getter
-        String contentType
+        String contentType,
+
+        @Schema(description = "PUT 요청 시 필수인 Content-Length 값(바이트). 요청한 contentLength 와 동일합니다.",
+            example = "1048576")
+        @Getter
+        Long contentLength,
+
+        @Schema(description = "해당 확장자에 허용된 최대 업로드 크기(바이트)",
+            example = "10485760")
+        @Getter
+        Long maxContentLength
 ) {
 }

--- a/src/main/java/com/afternote/domain/image/service/S3Service.java
+++ b/src/main/java/com/afternote/domain/image/service/S3Service.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
@@ -47,6 +48,22 @@ public class S3Service {
     @Value("${cloud.aws.public-base-url:}")
     private String publicBaseUrl;
 
+    /** 이미지 업로드 상한(바이트). 정책 미확정 임시값 — 설정으로 조정. */
+    @Value("${cloud.aws.s3.upload.max-bytes.image:10485760}")
+    private long maxImageBytes;
+
+    /** 영상 업로드 상한(바이트). 정책 미확정 임시값 — 설정으로 조정. */
+    @Value("${cloud.aws.s3.upload.max-bytes.video:209715200}")
+    private long maxVideoBytes;
+
+    /** 음성 업로드 상한(바이트). 정책 미확정 임시값 — 설정으로 조정. */
+    @Value("${cloud.aws.s3.upload.max-bytes.audio:52428800}")
+    private long maxAudioBytes;
+
+    /** 문서(PDF) 업로드 상한(바이트). 정책 미확정 임시값 — 설정으로 조정. */
+    @Value("${cloud.aws.s3.upload.max-bytes.document:20971520}")
+    private long maxDocumentBytes;
+
     private static final Set<String> ALLOWED_EXTENSIONS = Set.of(
             "jpg", "jpeg", "png", "gif", "webp", "heic",
             "mp4", "mov",
@@ -56,25 +73,34 @@ public class S3Service {
     private static final Set<String> ALLOWED_DIRECTORIES = Set.of(
             "profiles", "timeletters", "afternotes", "mindrecords", "documents"
     );
+    private static final Set<String> IMAGE_EXTENSIONS = Set.of(
+            "jpg", "jpeg", "png", "gif", "webp", "heic"
+    );
+    private static final Set<String> VIDEO_EXTENSIONS = Set.of("mp4", "mov");
+    private static final Set<String> AUDIO_EXTENSIONS = Set.of("mp3", "m4a", "wav");
     private static final Duration PRESIGNED_URL_EXPIRATION = Duration.ofMinutes(10);
 
     /**
-     * @deprecated {@link #generatePresignedUrl(String, String, Long)} 사용. owner 미지정 시 {@code receiver}.
+     * @deprecated {@link #generatePresignedUrl(String, String, Long, Long)} 사용. owner 미지정 시 {@code receiver}.
      */
-    public PresignedUrlResponse generatePresignedUrl(String directory, String extension) {
-        return generatePresignedUrl(directory, extension, null);
+    @Deprecated
+    public PresignedUrlResponse generatePresignedUrl(String directory, String extension, Long contentLength) {
+        return generatePresignedUrl(directory, extension, contentLength, null);
     }
 
     /**
      * 업로드용 presigned URL. 객체는 {@code {directory}/staging/{owner}/{uuid}.{ext}} 에 생성된다.
+     * {@code contentLength} 는 서명에 포함되므로 PUT 시 동일 Content-Length 헤더가 필수다.
      */
-    public PresignedUrlResponse generatePresignedUrl(String directory, String extension, Long userId) {
+    public PresignedUrlResponse generatePresignedUrl(String directory, String extension, Long contentLength, Long userId) {
         String normalizedDir = directory.toLowerCase();
         String normalizedExt = extension.toLowerCase().replaceFirst("^\\.", "");
         String owner = resolveOwnerSegment(userId);
 
         validateDirectory(normalizedDir);
         validateExtension(normalizedExt);
+        long maxContentLength = resolveMaxContentLength(normalizedExt);
+        validateContentLength(contentLength, maxContentLength);
 
         String fileName = UUID.randomUUID() + "." + normalizedExt;
         String key = buildStagingKey(normalizedDir, owner, fileName);
@@ -84,6 +110,7 @@ public class S3Service {
                 .bucket(bucket)
                 .key(key)
                 .contentType(contentType)
+                .contentLength(contentLength)
                 .build();
 
         PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
@@ -101,11 +128,38 @@ public class S3Service {
                     .fileKey(key)
                     .fileUrl(fileUrl)
                     .contentType(contentType)
+                    .contentLength(contentLength)
+                    .maxContentLength(maxContentLength)
                     .build();
         } catch (Exception e) {
             log.error("Presigned URL generation failed for key: {}", key, e);
             throw new CustomException(ErrorCode.PRESIGNED_URL_GENERATION_FAILED);
         }
+    }
+
+    /**
+     * staging/legacy 미디어를 permanent로 승격하고 storage key를 반환한다.
+     * 관리되지 않는 URL이면 기존처럼 extract 결과(또는 원문)를 반환한다.
+     */
+    public String promoteMediaKey(String directory, Long userId, String rawUrlOrKey) {
+        if (!StringUtils.hasText(rawUrlOrKey)) {
+            return rawUrlOrKey;
+        }
+
+        String key = extractStorageKey(rawUrlOrKey);
+        if (!StringUtils.hasText(key)) {
+            return rawUrlOrKey;
+        }
+
+        String normalizedDir = directory.toLowerCase();
+        String owner = resolveOwnerSegment(userId);
+        if (!belongsToDirectory(key, normalizedDir)) {
+            return key;
+        }
+        if (!isPromotableKey(key, normalizedDir, owner)) {
+            return key;
+        }
+        return promoteToPermanent(normalizedDir, owner, key);
     }
 
     /**
@@ -215,10 +269,28 @@ public class S3Service {
                     .destinationKey(permanentKey)
                     .build());
             log.debug("Promoted S3 object {} -> {}", sourceKey, permanentKey);
-            return permanentKey;
         } catch (Exception e) {
             log.error("S3 promote failed sourceKey={} permanentKey={}", sourceKey, permanentKey, e);
             throw new CustomException(ErrorCode.PRESIGNED_URL_GENERATION_FAILED);
+        }
+
+        if (isStagingKey(sourceKey, directory, owner)) {
+            deleteStagingOriginal(sourceKey);
+        }
+
+        return permanentKey;
+    }
+
+    private void deleteStagingOriginal(String sourceKey) {
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(sourceKey)
+                    .build());
+            log.debug("Deleted staging original {}", sourceKey);
+        } catch (Exception e) {
+            // permanent 사본은 이미 있으므로 승격 자체는 성공으로 두고, lifecycle 이 후속 정리한다.
+            log.warn("Failed to delete staging original after promote: {}", sourceKey, e);
         }
     }
 
@@ -319,6 +391,31 @@ public class S3Service {
         if (!ALLOWED_DIRECTORIES.contains(directory)) {
             throw new CustomException(ErrorCode.INVALID_DIRECTORY);
         }
+    }
+
+    private void validateContentLength(Long contentLength, long maxContentLength) {
+        if (contentLength == null || contentLength <= 0) {
+            throw new CustomException(ErrorCode.INVALID_FILE_SIZE);
+        }
+        if (contentLength > maxContentLength) {
+            throw new CustomException(ErrorCode.FILE_SIZE_EXCEEDED);
+        }
+    }
+
+    long resolveMaxContentLength(String extension) {
+        if (IMAGE_EXTENSIONS.contains(extension)) {
+            return maxImageBytes;
+        }
+        if (VIDEO_EXTENSIONS.contains(extension)) {
+            return maxVideoBytes;
+        }
+        if (AUDIO_EXTENSIONS.contains(extension)) {
+            return maxAudioBytes;
+        }
+        if ("pdf".equals(extension)) {
+            return maxDocumentBytes;
+        }
+        throw new CustomException(ErrorCode.INVALID_FILE_EXTENSION);
     }
 
     private String getContentType(String extension) {

--- a/src/main/java/com/afternote/domain/receiver/controller/ReceiverAuthController.java
+++ b/src/main/java/com/afternote/domain/receiver/controller/ReceiverAuthController.java
@@ -171,7 +171,9 @@ public class ReceiverAuthController {
             @RequestHeader("X-Auth-Code") String authCode,
             @Valid @RequestBody ReceiverPresignedUrlRequest request
     ) {
-        return ApiResponse.success(receiverAuthService.generatePresignedUrl(authCode, request.getExtension()));
+        return ApiResponse.success(
+                receiverAuthService.generatePresignedUrl(authCode, request.getExtension(), request.getContentLength())
+        );
     }
 
     @Operation(

--- a/src/main/java/com/afternote/domain/receiver/dto/ReceiverPresignedUrlRequest.java
+++ b/src/main/java/com/afternote/domain/receiver/dto/ReceiverPresignedUrlRequest.java
@@ -2,6 +2,8 @@ package com.afternote.domain.receiver.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 
 @Schema(description = "수신자 파일 업로드용 Presigned URL 요청")
@@ -10,6 +12,13 @@ public record ReceiverPresignedUrlRequest(
             allowableValues = {"jpg", "jpeg", "png", "gif", "webp", "heic", "pdf"})
         @NotBlank(message = "파일 확장자는 필수입니다.")
         @Getter
-        String extension
+        String extension,
+
+        @Schema(description = "업로드할 파일 크기(바이트). Presigned PUT 시 Content-Length 와 동일해야 합니다.",
+            example = "1048576")
+        @NotNull(message = "파일 크기는 필수입니다.")
+        @Positive(message = "파일 크기는 1바이트 이상이어야 합니다.")
+        @Getter
+        Long contentLength
 ) {
 }

--- a/src/main/java/com/afternote/domain/receiver/service/DeliveryVerificationService.java
+++ b/src/main/java/com/afternote/domain/receiver/service/DeliveryVerificationService.java
@@ -52,8 +52,11 @@ public class DeliveryVerificationService {
             throw new CustomException(ErrorCode.INVALID_DELIVERY_CONDITION);
         }
 
-        String deathCertKey = hasDeathCert ? s3Service.extractStorageKey(deathCertUrl) : null;
-        String familyRelationCertKey = hasFamilyCert ? s3Service.extractStorageKey(familyRelationCertUrl) : null;
+        // receiver 업로드는 owner=receiver staging → permanent 승격
+        String deathCertKey = hasDeathCert ? s3Service.promoteMediaKey("documents", null, deathCertUrl) : null;
+        String familyRelationCertKey = hasFamilyCert
+                ? s3Service.promoteMediaKey("documents", null, familyRelationCertUrl)
+                : null;
 
         if (deliveryVerificationRepository.existsByUserIdAndReceiverIdAndStatus(
                 user.getId(), receiver.getId(), VerificationStatus.PENDING)) {

--- a/src/main/java/com/afternote/domain/receiver/service/ReceiverAuthService.java
+++ b/src/main/java/com/afternote/domain/receiver/service/ReceiverAuthService.java
@@ -107,9 +107,9 @@ public class ReceiverAuthService {
         return new ReceiverMessageResponse(sender.getName(), receiver.getMessage(), receiver.getCreatedAt());
     }
 
-    public PresignedUrlResponse generatePresignedUrl(String authCode, String extension) {
+    public PresignedUrlResponse generatePresignedUrl(String authCode, String extension, Long contentLength) {
         findReceiverByAuthCode(authCode);
-        return s3Service.generatePresignedUrl("documents", extension, null);
+        return s3Service.generatePresignedUrl("documents", extension, contentLength, null);
     }
 
     public DeliveryVerificationResponse getDeliveryVerificationStatus(String authCode) {

--- a/src/main/java/com/afternote/domain/timeletter/service/TimeLetterService.java
+++ b/src/main/java/com/afternote/domain/timeletter/service/TimeLetterService.java
@@ -124,7 +124,7 @@ public class TimeLetterService {
                 .build();
 
         // 요청으로 받은 blocks를 TimeLetterBlock 엔티티로 변환 후 연결
-        List<TimeLetterBlock> blocks = buildBlocks(request.getBlocks());
+        List<TimeLetterBlock> blocks = buildBlocks(userId, request.getBlocks());
         timeLetter.replaceBlocks(blocks);
 
         // TimeLetter 저장
@@ -273,7 +273,7 @@ public class TimeLetterService {
         if (request.getBlocks() != null) {
             validateBlocks(request.getBlocks());
 
-            List<TimeLetterBlock> newBlocks = buildBlocks(request.getBlocks());
+            List<TimeLetterBlock> newBlocks = buildBlocks(userId, request.getBlocks());
             timeLetter.replaceBlocks(newBlocks);
         }
 
@@ -381,7 +381,7 @@ public class TimeLetterService {
      * - TEXT 블록은 textContent를 사용한다.
      * - IMAGE/AUDIO/FILE/LINK 블록은 url을 사용한다.
      */
-    private List<TimeLetterBlock> buildBlocks(List<TimeLetterBlockRequest> blockRequests) {
+    private List<TimeLetterBlock> buildBlocks(Long userId, List<TimeLetterBlockRequest> blockRequests) {
         if (blockRequests == null || blockRequests.isEmpty()) {
             return new ArrayList<>();
         }
@@ -393,7 +393,7 @@ public class TimeLetterService {
                         .blockType(req.getBlockType())
                         .blockOrder(req.getBlockOrder())
                         .textContent(req.getTextContent())
-                        .url(normalizeBlockUrl(req.getBlockType(), req.getUrl()))
+                        .url(normalizeBlockUrl(userId, req.getBlockType(), req.getUrl()))
                         .mimeType(req.getMimeType())
                         .build())
                 .collect(Collectors.toList());
@@ -478,10 +478,10 @@ public class TimeLetterService {
 
     /**
      * 블록 URL 정규화
-     * - IMAGE/AUDIO/FILE은 S3 key 또는 presigned URL이 들어올 수 있으므로 storage key로 정규화한다.
+     * - IMAGE/AUDIO/FILE은 staging/legacy를 permanent로 승격한 storage key로 저장한다.
      * - LINK는 외부 URL이므로 그대로 저장한다.
      */
-    private String normalizeBlockUrl(TimeLetterBlockType blockType, String rawUrlOrKey) {
+    private String normalizeBlockUrl(Long userId, TimeLetterBlockType blockType, String rawUrlOrKey) {
         if (rawUrlOrKey == null || rawUrlOrKey.isBlank()) {
             return rawUrlOrKey;
         }
@@ -490,7 +490,6 @@ public class TimeLetterService {
             return rawUrlOrKey;
         }
 
-        String key = s3Service.extractStorageKey(rawUrlOrKey);
-        return key != null ? key : rawUrlOrKey;
+        return s3Service.promoteMediaKey("timeletters", userId, rawUrlOrKey);
     }
 }

--- a/src/main/java/com/afternote/domain/user/service/UserService.java
+++ b/src/main/java/com/afternote/domain/user/service/UserService.java
@@ -57,8 +57,7 @@ public class UserService {
 
         String profileImageKey = request.getProfileImageUrl();
         if (profileImageKey != null && !profileImageKey.isBlank()) {
-            String extracted = s3Service.extractStorageKey(profileImageKey);
-            profileImageKey = extracted != null ? extracted : profileImageKey;
+            profileImageKey = s3Service.promoteMediaKey("profiles", userId, profileImageKey);
         }
 
         user.updateProfile(

--- a/src/main/java/com/afternote/global/exception/ErrorCode.java
+++ b/src/main/java/com/afternote/global/exception/ErrorCode.java
@@ -176,6 +176,8 @@ public enum ErrorCode {
     PRESIGNED_URL_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 1800, "Presigned URL 생성에 실패했습니다."),
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, 1801, "허용되지 않는 파일 확장자입니다. (jpg, jpeg, png, gif, webp, heic, mp4, mov, mp3, m4a, wav, pdf 허용)"),
     INVALID_DIRECTORY(HttpStatus.BAD_REQUEST, 1802, "허용되지 않는 디렉토리입니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, 1803, "업로드 파일 크기가 허용 한도를 초과했습니다."),
+    INVALID_FILE_SIZE(HttpStatus.BAD_REQUEST, 1804, "업로드 파일 크기는 1바이트 이상이어야 합니다."),
 
     // ======================================
     // 9. 수신자 인증/외부 API 관련 오류 (code: 1900 ~ 1999)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,6 +91,13 @@ cloud:
     s3:
       bucket: ${AWS_S3_BUCKET}
       region: ${AWS_REGION:ap-northeast-2}
+      # 업로드 크기 상한(바이트). 정책 미확정이므로 임시값 — 확정 시 여기만 조정.
+      upload:
+        max-bytes:
+          image: ${S3_UPLOAD_MAX_BYTES_IMAGE:10485760}       # 10MB (jpg/jpeg/png/gif/webp/heic)
+          video: ${S3_UPLOAD_MAX_BYTES_VIDEO:209715200}      # 200MB (mp4/mov)
+          audio: ${S3_UPLOAD_MAX_BYTES_AUDIO:52428800}       # 50MB (mp3/m4a/wav)
+          document: ${S3_UPLOAD_MAX_BYTES_DOCUMENT:20971520} # 20MB (pdf)
     public-base-url: ${AWS_PUBLIC_BASE_URL:}
     credentials:
       access-key: ${AWS_ACCESS_KEY}

--- a/src/test/java/com/afternote/domain/image/controller/ImageControllerTest.java
+++ b/src/test/java/com/afternote/domain/image/controller/ImageControllerTest.java
@@ -47,15 +47,15 @@ class ImageControllerTest {
     @Test
     @DisplayName("Presigned URL 생성 API 성공")
     void getPresignedUrl_Success() throws Exception {
-        given(s3Service.generatePresignedUrl("profiles", "jpg", USER_ID)).willReturn(null);
+        given(s3Service.generatePresignedUrl("profiles", "jpg", 1024L, USER_ID)).willReturn(null);
 
         mockMvc.perform(post("/api/v1/files/presigned-url")
                         .requestAttr(UserIdArgumentResolver.USER_ID_ATTRIBUTE, USER_ID)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"directory\":\"profiles\",\"extension\":\"jpg\"}"))
+                        .content("{\"directory\":\"profiles\",\"extension\":\"jpg\",\"contentLength\":1024}"))
                 .andExpect(status().isOk());
 
-        verify(s3Service).generatePresignedUrl("profiles", "jpg", USER_ID);
+        verify(s3Service).generatePresignedUrl("profiles", "jpg", 1024L, USER_ID);
     }
 
     @Test
@@ -64,7 +64,17 @@ class ImageControllerTest {
         mockMvc.perform(post("/api/v1/files/presigned-url")
                         .requestAttr(UserIdArgumentResolver.USER_ID_ATTRIBUTE, USER_ID)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"directory\":\"profiles\"}"))
+                        .content("{\"directory\":\"profiles\",\"contentLength\":1024}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Presigned URL 생성 API 실패 - contentLength 누락")
+    void getPresignedUrl_MissingContentLength_Fail() throws Exception {
+        mockMvc.perform(post("/api/v1/files/presigned-url")
+                        .requestAttr(UserIdArgumentResolver.USER_ID_ATTRIBUTE, USER_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"directory\":\"profiles\",\"extension\":\"jpg\"}"))
                 .andExpect(status().isBadRequest());
     }
 

--- a/src/test/java/com/afternote/domain/receiver/controller/ReceiverAuthControllerTest.java
+++ b/src/test/java/com/afternote/domain/receiver/controller/ReceiverAuthControllerTest.java
@@ -131,15 +131,15 @@ class ReceiverAuthControllerTest {
     @Test
     @DisplayName("수신자 Presigned URL API 성공")
     void getPresignedUrl_Success() throws Exception {
-        given(receiverAuthService.generatePresignedUrl(AUTH_CODE, "pdf")).willReturn(null);
+        given(receiverAuthService.generatePresignedUrl(AUTH_CODE, "pdf", 1024L)).willReturn(null);
 
         mockMvc.perform(post("/api/v1/receiver-auth/presigned-url")
                         .header("X-Auth-Code", AUTH_CODE)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"extension\":\"pdf\"}"))
+                        .content("{\"extension\":\"pdf\",\"contentLength\":1024}"))
                 .andExpect(status().isOk());
 
-        verify(receiverAuthService).generatePresignedUrl(AUTH_CODE, "pdf");
+        verify(receiverAuthService).generatePresignedUrl(AUTH_CODE, "pdf", 1024L);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Closes #141
- 승격(`copyObject`) 성공 후 staging 원본을 삭제하고, profiles·timeletters·afternotes·documents 저장 경로에도 permanent 승격을 적용합니다.
- presigned URL 발급에 `contentLength`를 서명해 종류별 업로드 상한(image 10MB / video 200MB / audio 50MB / document 20MB, 임시)을 강제합니다. 초과 시 HTTP 400 · `code: 1803`.
- 미승격 staging은 운영 버킷 lifecycle(3일)이 이미 걸려 있어 terraform은 추가하지 않았습니다.

## Test plan
- [ ] `POST /api/v1/files/presigned-url`에 `contentLength` 포함 시 URL 발급, 누락 시 400
- [ ] 한도 초과 `contentLength` → 400 / `1803`
- [ ] 발급된 URL로 PUT 시 `Content-Length`가 요청값과 같아야 성공
- [ ] mindrecord / profile / timeletter / playlist / documents 저장 후 S3 키가 `.../permanent/...` 이고 staging 원본이 사라지는지 확인
- [ ] FE: `contentLength` 전달·초과 안내 문구 연동


Made with [Cursor](https://cursor.com)