### PR TITLE
fix: #131 week[] emotion을 todayMood만 사용

### DIFF
--- a/src/main/java/com/afternote/domain/mindrecord/weekly/dto/WeeklyMindRecordResponse.java
+++ b/src/main/java/com/afternote/domain/mindrecord/weekly/dto/WeeklyMindRecordResponse.java
@@ -73,8 +73,16 @@ public record WeeklyMindRecordResponse(
             @Getter
             int day,
 
+            @Schema(description = "일기 여부. true면 일기, false면 데일리질문/깊은생각 등")
             boolean isDiary,
 
+            @Schema(
+                    description = "주간 캘린더 이모지용 일기 todayMood (HAPPY/SOSO/SAD). "
+                            + "일기만 채우고, Gemini 감정분석 결과는 emotions[]에만 둔다.",
+                    example = "HAPPY",
+                    allowableValues = {"HAPPY", "SOSO", "SAD"},
+                    nullable = true
+            )
             @Getter
             String emotion
     ) {

--- a/src/main/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordService.java
+++ b/src/main/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordService.java
@@ -44,8 +44,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -101,13 +99,6 @@ public class WeeklyMindRecordService {
                         userId, rangeStart, rangeEndExclusive
                 );
 
-        Map<Long, String> diaryEmotion = emotionMap(
-                userId, EmotionSourceType.DIARY, diaries.stream().map(Diary::getId).toList());
-        Map<Long, String> dqEmotion = emotionMap(
-                userId, EmotionSourceType.DAILY_QUESTION, dailyQuestions.stream().map(UserDailyQuestion::getId).toList());
-        Map<Long, String> dtEmotion = emotionMap(
-                userId, EmotionSourceType.DEEP_THOUGHT, deepThoughts.stream().map(DeepThought::getId).toList());
-
         List<Emotion> weekEmotions = collectWeekEmotions(userId, diaries, dailyQuestions, deepThoughts);
         List<WeeklyEmotionItem> topEmotions = buildTopEmotions(weekEmotions);
         EmotionAnalysisSummary emotionAnalysis = buildEmotionAnalysisSummary(
@@ -118,7 +109,8 @@ public class WeeklyMindRecordService {
 
         String summaryText = resolveSummaryText(user, weekMonday, storedStart, storedEnd, keywordJson, topEmotions);
 
-        List<WeekRecordItem> week = buildWeekItems(diaries, dailyQuestions, deepThoughts, diaryEmotion, dqEmotion, dtEmotion);
+        // week[] 캘린더는 일기 todayMood 이모지용. Gemini 감정분석(emotions[])과 분리한다.
+        List<WeekRecordItem> week = buildWeekItems(diaries, dailyQuestions, deepThoughts);
 
         List<WeeklyDailyQuestionItem> dqItems = dailyQuestions.stream()
                 .map(udq -> WeeklyDailyQuestionItem.builder()
@@ -233,18 +225,6 @@ public class WeeklyMindRecordService {
         }
     }
 
-    private Map<Long, String> emotionMap(Long userId, EmotionSourceType type, List<Long> sourceIds) {
-        if (sourceIds.isEmpty()) {
-            return Map.of();
-        }
-        return emotionRepository
-                .findByUserIdAndSourceTypeAndSourceIdInAndStatus(
-                        userId, type, sourceIds, EmotionAnalysisStatus.SUCCEEDED)
-                .stream()
-                .filter(Emotion::isSucceeded)
-                .collect(Collectors.toMap(Emotion::getSourceId, Emotion::getEmotionCategory, (a, b) -> a));
-    }
-
     private List<Emotion> collectWeekEmotions(
             Long userId,
             List<Diary> diaries,
@@ -330,10 +310,7 @@ public class WeeklyMindRecordService {
     private List<WeekRecordItem> buildWeekItems(
             List<Diary> diaries,
             List<UserDailyQuestion> dailyQuestions,
-            List<DeepThought> deepThoughts,
-            Map<Long, String> diaryEmotion,
-            Map<Long, String> dqEmotion,
-            Map<Long, String> dtEmotion
+            List<DeepThought> deepThoughts
     ) {
         record Sortable(LocalDateTime at, WeekRecordItem item) {
         }
@@ -342,26 +319,23 @@ public class WeeklyMindRecordService {
 
         for (Diary d : diaries) {
             LocalDateTime at = d.getCreatedAt() != null ? d.getCreatedAt() : d.getUpdatedAt();
-            String analyzed = diaryEmotion.get(d.getId());
-            String emotion = analyzed != null && !analyzed.isBlank()
-                    ? analyzed
-                    : (d.getTodayMood() != null ? d.getTodayMood().name() : null);
+            // 캘린더 이모지 = todayMood 만 (HAPPY/SOSO/SAD). 분석 카테고리는 emotions[] 전용.
+            String todayMood = d.getTodayMood() != null ? d.getTodayMood().name() : null;
             sortables.add(new Sortable(at, WeekRecordItem.builder()
                     .diaryId(d.getId())
                     .day(at.toLocalDate().getDayOfMonth())
                     .isDiary(true)
-                    .emotion(emotion)
+                    .emotion(todayMood)
                     .build()));
         }
 
         for (UserDailyQuestion u : dailyQuestions) {
             LocalDateTime at = u.getCreatedAt() != null ? u.getCreatedAt() : u.getQuestionDate().atStartOfDay();
-            String emotion = dqEmotion.get(u.getId());
             sortables.add(new Sortable(at, WeekRecordItem.builder()
                     .diaryId(u.getId())
                     .day(u.getQuestionDate().getDayOfMonth())
                     .isDiary(false)
-                    .emotion(emotion)
+                    .emotion(null)
                     .build()));
         }
 
@@ -371,7 +345,7 @@ public class WeeklyMindRecordService {
                     .diaryId(dt.getId())
                     .day(at.toLocalDate().getDayOfMonth())
                     .isDiary(false)
-                    .emotion(dtEmotion.get(dt.getId()))
+                    .emotion(null)
                     .build()));
         }
 

--- a/src/test/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordServiceWeekItemsTest.java
+++ b/src/test/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordServiceWeekItemsTest.java
@@ -1,0 +1,148 @@
+package com.afternote.domain.mindrecord.weekly.service;
+
+import com.afternote.domain.dailyquestion.model.DailyQuestion;
+import com.afternote.domain.dailyquestion.model.UserDailyQuestion;
+import com.afternote.domain.dailyquestion.repository.UserDailyQuestionRepository;
+import com.afternote.domain.deepthought.repository.DeepThoughtRepository;
+import com.afternote.domain.diary.model.Diary;
+import com.afternote.domain.diary.model.TodayMood;
+import com.afternote.domain.diary.repository.DiaryRepository;
+import com.afternote.domain.mindrecord.emotion.model.Emotion;
+import com.afternote.domain.mindrecord.emotion.model.EmotionSourceType;
+import com.afternote.domain.mindrecord.emotion.repository.EmotionRepository;
+import com.afternote.domain.mindrecord.weekly.dto.WeeklyMindRecordResponse.WeekRecordItem;
+import com.afternote.domain.mindrecord.weekly.repository.WeeklyReportRepository;
+import com.afternote.domain.user.model.AuthProvider;
+import com.afternote.domain.user.model.User;
+import com.afternote.domain.user.model.UserStatus;
+import com.afternote.domain.user.repository.UserRepository;
+import com.afternote.global.service.GeminiService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class WeeklyMindRecordServiceWeekItemsTest {
+
+    @InjectMocks
+    private WeeklyMindRecordService weeklyMindRecordService;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private DiaryRepository diaryRepository;
+    @Mock
+    private UserDailyQuestionRepository userDailyQuestionRepository;
+    @Mock
+    private DeepThoughtRepository deepThoughtRepository;
+    @Mock
+    private EmotionRepository emotionRepository;
+    @Mock
+    private WeeklyReportRepository weeklyReportRepository;
+    @Mock
+    private GeminiService geminiService;
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("week[].emotion 은 todayMood만 쓰고 Gemini 분석 카테고리는 넣지 않는다")
+    void weekEmotion_usesTodayMoodOnly_notAnalyzedCategory() throws Exception {
+        ReflectionTestUtils.setField(weeklyMindRecordService, "objectMapper", new ObjectMapper());
+
+        User user = sampleUser(1L);
+        LocalDate monday = LocalDate.of(2026, 8, 3);
+
+        Diary diary = Diary.create(user, "제목", "본문", false, TodayMood.HAPPY);
+        ReflectionTestUtils.setField(diary, "id", 7L);
+        ReflectionTestUtils.setField(diary, "createdAt", monday.plusDays(1).atTime(10, 0));
+        ReflectionTestUtils.setField(diary, "updatedAt", monday.plusDays(1).atTime(10, 0));
+
+        DailyQuestion question = new DailyQuestion();
+        ReflectionTestUtils.setField(question, "id", 1L);
+        ReflectionTestUtils.setField(question, "content", "질문");
+
+        UserDailyQuestion dq = UserDailyQuestion.builder()
+                .user(user)
+                .dailyQuestion(question)
+                .questionDate(monday.plusDays(1))
+                .isAnswered(true)
+                .content("답변")
+                .isDraft(false)
+                .build();
+        ReflectionTestUtils.setField(dq, "id", 22L);
+        ReflectionTestUtils.setField(dq, "createdAt", monday.plusDays(1).atTime(11, 0));
+
+        Emotion analyzed = Emotion.createSucceeded(
+                user, EmotionSourceType.DIARY, 7L, "기쁨", LocalDateTime.now());
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(diaryRepository
+                .findByUserIdAndIsDraftFalseAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtAsc(
+                        any(), any(), any()))
+                .willReturn(List.of(diary));
+        given(userDailyQuestionRepository
+                .findByUserIdAndQuestionDateBetweenOrderByQuestionDateAscCreatedAtAsc(any(), any(), any()))
+                .willReturn(List.of(dq));
+        given(deepThoughtRepository
+                .findByUserIdAndIsDraftFalseAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtAsc(
+                        any(), any(), any()))
+                .willReturn(List.of());
+        given(emotionRepository.findByUserIdAndSourceTypeAndSourceIdIn(
+                eq(1L), eq(EmotionSourceType.DIARY), anyList()))
+                .willReturn(List.of(analyzed));
+        given(emotionRepository.findByUserIdAndSourceTypeAndSourceIdIn(
+                eq(1L), eq(EmotionSourceType.DAILY_QUESTION), anyList()))
+                .willReturn(List.of());
+        given(weeklyReportRepository.findByUserIdAndStartDate(any(), any())).willReturn(Optional.empty());
+        given(geminiService.generateWeeklyMindRecordSummary(any())).willReturn("요약");
+
+        var response = weeklyMindRecordService.getWeeklyMindRecord(1L, monday);
+
+        assertThat(response.week()).hasSize(2);
+
+        WeekRecordItem diaryItem = response.week().stream()
+                .filter(WeekRecordItem::isDiary)
+                .findFirst()
+                .orElseThrow();
+        assertThat(diaryItem.emotion()).isEqualTo("HAPPY");
+        assertThat(diaryItem.emotion()).isNotEqualTo("기쁨");
+
+        WeekRecordItem dqItem = response.week().stream()
+                .filter(item -> !item.isDiary())
+                .findFirst()
+                .orElseThrow();
+        assertThat(dqItem.emotion()).isNull();
+
+        assertThat(response.emotions())
+                .extracting(e -> e.keyword())
+                .contains("기쁨");
+    }
+
+    private static User sampleUser(Long id) {
+        User user = User.builder()
+                .email("u@test.com")
+                .password("pw")
+                .name("tester")
+                .status(UserStatus.ACTIVE)
+                .provider(AuthProvider.LOCAL)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}


### PR DESCRIPTION
## Summary
- `week[].emotion`에 Gemini 분석 카테고리(한글)가 들어가 FE 이모지가 깨지던 문제를 수정
- 캘린더용 값은 일기 `todayMood`만 사용하고, 분석 결과는 `emotions[]`에만 유지
- 데일리질문/깊은생각의 `week[].emotion`은 null(점 표시용)

## Test plan
- [x] `WeeklyMindRecordServiceWeekItemsTest` — todayMood만 내려가고 분석값 `기쁨`은 week에 없음
- [ ] 배포 후 일기 HAPPY 저장 → 분석 완료 뒤에도 `week[].emotion`이 `HAPPY`인지 확인

Fixes #131


Made with [Cursor](https://cursor.com)