### PR TITLE
feat: 애프터노트 임시저장(isDraft) 지원 (#130)

### DIFF
--- a/src/main/java/com/afternote/domain/afternote/controller/AfternoteController.java
+++ b/src/main/java/com/afternote/domain/afternote/controller/AfternoteController.java
@@ -30,7 +30,8 @@ public class AfternoteController {
 
     @Operation(
             summary = "애프터노트 목록 조회 API",
-            description = "애프터노트 목록을 가져옵니다. param으로 category와 page, size를 보내주시면 됩니다."
+            description = "애프터노트 목록을 가져옵니다. 기본은 정식 등록(isDraft=false)만 반환하며, "
+                    + "draftOnly=true이면 임시저장만 반환합니다."
     )
     @GetMapping
     public ApiResponse<AfternotePageResponse> getAfternotes(
@@ -48,9 +49,12 @@ public class AfternoteController {
             @RequestParam(defaultValue = "10")
             @Min(value = 1, message = "size는 1 이상이어야 합니다.")
             @Max(value = 100, message = "size는 100 이하여야 합니다.")
-            int size
+            int size,
+
+            @Parameter(description = "true면 임시저장(isDraft=true)만 조회")
+            @RequestParam(required = false) Boolean draftOnly
     ) {
-        AfternotePageResponse response = afternoteService.getAfternotes(userId, category, page, size);
+        AfternotePageResponse response = afternoteService.getAfternotes(userId, category, page, size, draftOnly);
         return ApiResponse.success(response);
     }
 
@@ -74,7 +78,8 @@ public class AfternoteController {
     }
     @Operation(
             summary = "애프터노트 생성 API",
-            description = "새로운 애프터노트를 생성합니다. 카테고리에 따라 다른 필드를 전달해야 합니다."
+            description = "새로운 애프터노트를 생성합니다. 카테고리에 따라 다른 필드를 전달해야 합니다. "
+                    + "isDraft=true이면 credentials/playlist 등 일부 필수 검증이 완화됩니다."
     )
     @PostMapping
     public ApiResponse<AfternoteCreateResponse> createAfternote(

--- a/src/main/java/com/afternote/domain/afternote/dto/AfternoteCreateRequest.java
+++ b/src/main/java/com/afternote/domain/afternote/dto/AfternoteCreateRequest.java
@@ -39,8 +39,16 @@ public record AfternoteCreateRequest(
 
         @Schema(description = "플레이리스트 정보 (Playlist 전용)")
         @Getter
-        PlaylistRequest playlist
+        PlaylistRequest playlist,
+
+        @Schema(description = "임시저장 여부. true면 credentials/playlist 필수 검증 완화. 생략 시 false", example = "false")
+        @Getter
+        Boolean isDraft
 ) {
+
+    public boolean isDraftValue() {
+        return Boolean.TRUE.equals(isDraft);
+    }
 
     
 

--- a/src/main/java/com/afternote/domain/afternote/dto/AfternoteResponse.java
+++ b/src/main/java/com/afternote/domain/afternote/dto/AfternoteResponse.java
@@ -21,6 +21,10 @@ public record AfternoteResponse(
         @Getter
         AfternoteCategoryType category,
 
+        @Schema(description = "임시저장 여부", example = "false")
+        @Getter
+        Boolean isDraft,
+
         @Schema(description = "생성일시", example = "2025-11-26T14:30:00")
         @Getter
         LocalDateTime createdAt

--- a/src/main/java/com/afternote/domain/afternote/dto/AfternotedetailResponse.java
+++ b/src/main/java/com/afternote/domain/afternote/dto/AfternotedetailResponse.java
@@ -20,6 +20,10 @@ public record AfternotedetailResponse(
         @Getter
         String title,
 
+        @Schema(description = "임시저장 여부", example = "false")
+        @Getter
+        Boolean isDraft,
+
         @Schema(description = "체크리스트 (SOCIAL/GALLERY 전용)")
         @Getter
         List<String> actions,

--- a/src/main/java/com/afternote/domain/afternote/model/Afternote.java
+++ b/src/main/java/com/afternote/domain/afternote/model/Afternote.java
@@ -4,6 +4,7 @@ import com.afternote.domain.afternote.dto.LeaveMessageBlock;
 import com.afternote.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +33,11 @@ public class Afternote extends BaseEntity {
     
     @Column(nullable = false, length = 100)
     private String title;
+
+    @ColumnDefault("false")
+    @Column(name = "is_draft", nullable = false)
+    @Builder.Default
+    private Boolean isDraft = false;
     
     @Convert(converter = LeaveMessageListConverter.class)
     @Column(columnDefinition = "TEXT")
@@ -58,13 +64,16 @@ public class Afternote extends BaseEntity {
     private AfternotePlaylist playlist;
 
     // 업데이트 메서드
-    public void update(String title, Integer sortOrder, List<LeaveMessageBlock> leaveMessage, List<String> actions) {
+    public void update(String title, Integer sortOrder, List<LeaveMessageBlock> leaveMessage, List<String> actions, Boolean isDraft) {
         this.title = title;
         this.sortOrder = sortOrder;
         this.leaveMessage = leaveMessage;
         this.actions.clear();
         if (actions != null) {
             this.actions.addAll(actions);
+        }
+        if (isDraft != null) {
+            this.isDraft = isDraft;
         }
     }
 

--- a/src/main/java/com/afternote/domain/afternote/repository/AfternoteRepository.java
+++ b/src/main/java/com/afternote/domain/afternote/repository/AfternoteRepository.java
@@ -18,13 +18,20 @@ public interface AfternoteRepository extends JpaRepository<Afternote, Long> {
     @Query("SELECT a.id FROM Afternote a WHERE a.user.id = :userId")
     List<Long> findIdsByUserId(@Param("userId") Long userId);
     
-    // 전체 목록 페이징 조회
-    @Query("SELECT a FROM Afternote a WHERE a.user.id = :userId ORDER BY a.createdAt DESC")
-    Page<Afternote> findByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId, Pageable pageable);
+    // 전체 목록 페이징 조회 (isDraft 필터)
+    @Query("SELECT a FROM Afternote a WHERE a.user.id = :userId AND a.isDraft = :isDraft ORDER BY a.createdAt DESC")
+    Page<Afternote> findByUserIdAndIsDraftOrderByCreatedAtDesc(
+            @Param("userId") Long userId,
+            @Param("isDraft") Boolean isDraft,
+            Pageable pageable);
     
-    // 카테고리별 필터링 페이징 조회
-    @Query("SELECT a FROM Afternote a WHERE a.user.id = :userId AND a.categoryType = :categoryType ORDER BY a.createdAt DESC")
-    Page<Afternote> findByUserIdAndCategoryTypeOrderByCreatedAtDesc(@Param("userId") Long userId, @Param("categoryType") AfternoteCategoryType categoryType, Pageable pageable);
+    // 카테고리별 필터링 페이징 조회 (isDraft 필터)
+    @Query("SELECT a FROM Afternote a WHERE a.user.id = :userId AND a.categoryType = :categoryType AND a.isDraft = :isDraft ORDER BY a.createdAt DESC")
+    Page<Afternote> findByUserIdAndCategoryTypeAndIsDraftOrderByCreatedAtDesc(
+            @Param("userId") Long userId,
+            @Param("categoryType") AfternoteCategoryType categoryType,
+            @Param("isDraft") Boolean isDraft,
+            Pageable pageable);
     
     // 해당 사용자의 최대 sortOrder 조회
     @Query("SELECT MAX(a.sortOrder) FROM Afternote a WHERE a.user.id = :userId")

--- a/src/main/java/com/afternote/domain/afternote/service/AfternoteService.java
+++ b/src/main/java/com/afternote/domain/afternote/service/AfternoteService.java
@@ -31,7 +31,13 @@ public class AfternoteService {
     private final ChaChaEncryptionUtil chaChaEncryptionUtil;
     private final S3Service s3Service;
 
-    public AfternotePageResponse getAfternotes(Long userId, AfternoteCategoryType category, Integer page, Integer size) {
+    public AfternotePageResponse getAfternotes(
+            Long userId,
+            AfternoteCategoryType category,
+            Integer page,
+            Integer size,
+            Boolean draftOnly
+    ) {
         if (page == null || page < 0 || size == null || size < 1) {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
@@ -40,13 +46,16 @@ public class AfternoteService {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
+        boolean isDraft = Boolean.TRUE.equals(draftOnly);
         Pageable pageable = PageRequest.of(page, size);
         Page<Afternote> afternotePage;
         
         if (category != null) {
-            afternotePage = afternoteRepository.findByUserIdAndCategoryTypeOrderByCreatedAtDesc(userId, category, pageable);
+            afternotePage = afternoteRepository.findByUserIdAndCategoryTypeAndIsDraftOrderByCreatedAtDesc(
+                    userId, category, isDraft, pageable);
         } else {
-            afternotePage = afternoteRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+            afternotePage = afternoteRepository.findByUserIdAndIsDraftOrderByCreatedAtDesc(
+                    userId, isDraft, pageable);
         }
         
         List<AfternoteResponse> content = afternotePage.getContent().stream()
@@ -54,6 +63,7 @@ public class AfternoteService {
                         .afternoteId(afternote.getId())
                         .title(afternote.getTitle())
                         .category(afternote.getCategoryType())
+                        .isDraft(Boolean.TRUE.equals(afternote.getIsDraft()))
                         .createdAt(afternote.getCreatedAt())
                         .build())
                 .collect(Collectors.toList());
@@ -106,6 +116,7 @@ public class AfternoteService {
                         afternote.getId(),
                         afternote.getCategoryType(),
                         afternote.getTitle(),
+                        Boolean.TRUE.equals(afternote.getIsDraft()),
                         afternote.getActions(),
                         afternote.getLeaveMessage(),
                         credentials,
@@ -120,6 +131,7 @@ public class AfternoteService {
                         afternote.getId(),
                         afternote.getCategoryType(),
                         afternote.getTitle(),
+                        Boolean.TRUE.equals(afternote.getIsDraft()),
                         afternote.getActions(),
                         afternote.getLeaveMessage(),
                         null,
@@ -172,6 +184,7 @@ public class AfternoteService {
                         afternote.getId(),
                         afternote.getCategoryType(),
                         afternote.getTitle(),
+                        Boolean.TRUE.equals(afternote.getIsDraft()),
                         null,
                         afternote.getLeaveMessage(),
                         null,
@@ -186,6 +199,7 @@ public class AfternoteService {
                         afternote.getId(),
                         afternote.getCategoryType(),
                         afternote.getTitle(),
+                        Boolean.TRUE.equals(afternote.getIsDraft()),
                         afternote.getActions(),
                         afternote.getLeaveMessage(),
                         null,
@@ -218,6 +232,7 @@ public class AfternoteService {
                 .user(user)
                 .categoryType(request.getCategory())
                 .title(request.getTitle())
+                .isDraft(request.isDraftValue())
                 .sortOrder(nextSortOrder)
                 .leaveMessage(request.getLeaveMessage());
 
@@ -249,6 +264,8 @@ public class AfternoteService {
         }
         // PATCH용 검증 (카테고리 변경 불가 체크)
         validator.validateUpdateRequest(request, afternote.getCategoryType());
+        // 정식 등록으로 남거나 전환될 때 필수값 검증
+        validator.validatePublishRequirements(request, afternote);
 
         // 기본 필드 업데이트 (null이 아닌 경우만)
         String title = request.getTitle() != null ? request.getTitle() : afternote.getTitle();
@@ -266,7 +283,7 @@ public class AfternoteService {
             actions = new ArrayList<>(request.getActions());
         }
 
-        afternote.update(title, afternote.getSortOrder(), leaveMessage, actions);
+        afternote.update(title, afternote.getSortOrder(), leaveMessage, actions, request.getIsDraft());
 
         // 관계 데이터 업데이트 (카테고리 전략 + 공통 receivers 처리)
         relationService.updateRelationsByCategory(afternote, request, afternote.getCategoryType());

--- a/src/main/java/com/afternote/domain/afternote/service/AfternoteValidator.java
+++ b/src/main/java/com/afternote/domain/afternote/service/AfternoteValidator.java
@@ -1,7 +1,9 @@
 package com.afternote.domain.afternote.service;
 
 import com.afternote.domain.afternote.dto.AfternoteCreateRequest;
+import com.afternote.domain.afternote.model.Afternote;
 import com.afternote.domain.afternote.model.AfternoteCategoryType;
+import com.afternote.domain.afternote.service.relation.EncryptedKey;
 import com.afternote.domain.afternote.service.validation.AfternoteCategoryValidationStrategy;
 import com.afternote.domain.afternote.service.validation.AfternoteValidationCommons;
 import com.afternote.domain.afternote.service.validation.AfternoteValidationStrategyFactory;
@@ -49,5 +51,67 @@ public class AfternoteValidator {
         AfternoteValidationCommons.validateLeaveMessage(request.getLeaveMessage());
         AfternoteCategoryValidationStrategy strategy = validationStrategyFactory.get(category);
         strategy.validateUpdate(request);
+    }
+
+    /**
+     * 정식 등록(비-draft) 상태로 남을 때 credentials/playlist 등 필수값 검증.
+     * PATCH는 부분 갱신이므로 request + 기존 엔티티를 함께 본다.
+     */
+    public void validatePublishRequirements(AfternoteCreateRequest request, Afternote afternote) {
+        boolean willBeDraft = request.getIsDraft() != null
+                ? Boolean.TRUE.equals(request.getIsDraft())
+                : Boolean.TRUE.equals(afternote.getIsDraft());
+        if (willBeDraft) {
+            return;
+        }
+
+        switch (afternote.getCategoryType()) {
+            case SOCIAL -> validateSocialPublish(request, afternote);
+            case PLAYLIST -> validatePlaylistPublish(request, afternote);
+            default -> {
+                // GALLERY: 추가 필수 없음
+            }
+        }
+    }
+
+    private void validateSocialPublish(AfternoteCreateRequest request, Afternote afternote) {
+        boolean hasId = hasNonBlank(request.getCredentials() != null ? request.getCredentials().getId() : null)
+                || hasSecureKey(afternote, EncryptedKey.ACCOUNT_ID);
+        boolean hasPassword = hasNonBlank(request.getCredentials() != null ? request.getCredentials().getPassword() : null)
+                || hasSecureKey(afternote, EncryptedKey.ACCOUNT_PASSWORD);
+
+        if (!hasId || !hasPassword) {
+            if (!hasId && !hasPassword) {
+                throw new CustomException(ErrorCode.SOCIAL_CREDENTIALS_REQUIRED);
+            }
+            if (!hasId) {
+                throw new CustomException(ErrorCode.SOCIAL_ACCOUNT_ID_REQUIRED);
+            }
+            throw new CustomException(ErrorCode.SOCIAL_ACCOUNT_PASSWORD_REQUIRED);
+        }
+    }
+
+    private void validatePlaylistPublish(AfternoteCreateRequest request, Afternote afternote) {
+        if (request.getPlaylist() != null) {
+            if (request.getPlaylist().getSongs() == null || request.getPlaylist().getSongs().isEmpty()) {
+                throw new CustomException(ErrorCode.PLAYLIST_SONGS_REQUIRED);
+            }
+            return;
+        }
+        if (afternote.getPlaylist() == null
+                || afternote.getPlaylist().getItems() == null
+                || afternote.getPlaylist().getItems().isEmpty()) {
+            throw new CustomException(ErrorCode.PLAYLIST_REQUIRED);
+        }
+    }
+
+    private boolean hasSecureKey(Afternote afternote, EncryptedKey key) {
+        return afternote.getSecureContents() != null
+                && afternote.getSecureContents().stream()
+                .anyMatch(sc -> key.matches(sc.getKeyName()));
+    }
+
+    private boolean hasNonBlank(String value) {
+        return value != null && !value.isBlank();
     }
 }

--- a/src/main/java/com/afternote/domain/afternote/service/validation/PlaylistValidationStrategy.java
+++ b/src/main/java/com/afternote/domain/afternote/service/validation/PlaylistValidationStrategy.java
@@ -23,19 +23,11 @@ public class PlaylistValidationStrategy implements AfternoteCategoryValidationSt
             throw new CustomException(ErrorCode.INVALID_FIELD_FOR_PLAYLIST);
         }
 
-        if (request.getPlaylist() == null) {
-            throw new CustomException(ErrorCode.PLAYLIST_REQUIRED);
-        }
-        if (request.getPlaylist().getSongs() == null || request.getPlaylist().getSongs().isEmpty()) {
-            throw new CustomException(ErrorCode.PLAYLIST_SONGS_REQUIRED);
-        }
-        for (AfternoteCreateRequest.SongRequest song : request.getPlaylist().getSongs()) {
-            if (song.getTitle() == null || song.getTitle().isBlank()) {
-                throw new CustomException(ErrorCode.PLAYLIST_SONG_TITLE_REQUIRED);
-            }
-            if (song.getArtist() == null || song.getArtist().isBlank()) {
-                throw new CustomException(ErrorCode.PLAYLIST_SONG_ARTIST_REQUIRED);
-            }
+        // draft면 playlist/songs 필수 검증 완화
+        if (!request.isDraftValue()) {
+            requirePlaylistSongs(request);
+        } else if (request.getPlaylist() != null && request.getPlaylist().getSongs() != null) {
+            validateSongFields(request.getPlaylist().getSongs());
         }
 
         // receivers 는 선택 (없으면 빈 상태로 생성)
@@ -51,6 +43,31 @@ public class PlaylistValidationStrategy implements AfternoteCategoryValidationSt
             throw new CustomException(ErrorCode.INVALID_FIELD_FOR_PLAYLIST);
         }
 
+        if (request.getPlaylist() != null && request.getPlaylist().getSongs() != null) {
+            validateSongFields(request.getPlaylist().getSongs());
+        }
+
         AfternoteValidationCommons.validateOptionalReceivers(request);
+    }
+
+    private void requirePlaylistSongs(AfternoteCreateRequest request) {
+        if (request.getPlaylist() == null) {
+            throw new CustomException(ErrorCode.PLAYLIST_REQUIRED);
+        }
+        if (request.getPlaylist().getSongs() == null || request.getPlaylist().getSongs().isEmpty()) {
+            throw new CustomException(ErrorCode.PLAYLIST_SONGS_REQUIRED);
+        }
+        validateSongFields(request.getPlaylist().getSongs());
+    }
+
+    private void validateSongFields(java.util.List<AfternoteCreateRequest.SongRequest> songs) {
+        for (AfternoteCreateRequest.SongRequest song : songs) {
+            if (song.getTitle() == null || song.getTitle().isBlank()) {
+                throw new CustomException(ErrorCode.PLAYLIST_SONG_TITLE_REQUIRED);
+            }
+            if (song.getArtist() == null || song.getArtist().isBlank()) {
+                throw new CustomException(ErrorCode.PLAYLIST_SONG_ARTIST_REQUIRED);
+            }
+        }
     }
 }

--- a/src/main/java/com/afternote/domain/afternote/service/validation/SocialValidationStrategy.java
+++ b/src/main/java/com/afternote/domain/afternote/service/validation/SocialValidationStrategy.java
@@ -21,14 +21,9 @@ public class SocialValidationStrategy implements AfternoteCategoryValidationStra
         }
 
         // actions·receivers 는 선택 (없으면 빈 상태로 생성)
-        if (request.getCredentials() == null) {
-            throw new CustomException(ErrorCode.SOCIAL_CREDENTIALS_REQUIRED);
-        }
-        if (request.getCredentials().getId() == null || request.getCredentials().getId().isBlank()) {
-            throw new CustomException(ErrorCode.SOCIAL_ACCOUNT_ID_REQUIRED);
-        }
-        if (request.getCredentials().getPassword() == null || request.getCredentials().getPassword().isBlank()) {
-            throw new CustomException(ErrorCode.SOCIAL_ACCOUNT_PASSWORD_REQUIRED);
+        // draft면 credentials 필수 검증 완화
+        if (!request.isDraftValue()) {
+            requireCredentials(request);
         }
 
         AfternoteValidationCommons.validateOptionalReceivers(request);
@@ -41,6 +36,18 @@ public class SocialValidationStrategy implements AfternoteCategoryValidationStra
         }
         // receivers·credentials·title·actions·leaveMessage 는 수정 허용
         AfternoteValidationCommons.validateOptionalReceivers(request);
+    }
+
+    private void requireCredentials(AfternoteCreateRequest request) {
+        if (request.getCredentials() == null) {
+            throw new CustomException(ErrorCode.SOCIAL_CREDENTIALS_REQUIRED);
+        }
+        if (request.getCredentials().getId() == null || request.getCredentials().getId().isBlank()) {
+            throw new CustomException(ErrorCode.SOCIAL_ACCOUNT_ID_REQUIRED);
+        }
+        if (request.getCredentials().getPassword() == null || request.getCredentials().getPassword().isBlank()) {
+            throw new CustomException(ErrorCode.SOCIAL_ACCOUNT_PASSWORD_REQUIRED);
+        }
     }
 
 }

--- a/src/main/java/com/afternote/domain/receiver/repository/AfternoteReceiverRepository.java
+++ b/src/main/java/com/afternote/domain/receiver/repository/AfternoteReceiverRepository.java
@@ -17,6 +17,7 @@ public interface AfternoteReceiverRepository extends JpaRepository<AfternoteRece
             SELECT ar FROM AfternoteReceiver ar
             JOIN FETCH ar.afternote a
             WHERE ar.receiver.id = :receiverId
+              AND a.isDraft = false
             ORDER BY a.createdAt DESC
             """)
     List<AfternoteReceiver> findByReceiverIdWithAfternote(@Param("receiverId") Long receiverId);
@@ -24,7 +25,9 @@ public interface AfternoteReceiverRepository extends JpaRepository<AfternoteRece
     @Query("""
             SELECT ar FROM AfternoteReceiver ar
             JOIN FETCH ar.afternote a
-            WHERE a.id = :afternoteId AND ar.receiver.id = :receiverId
+            WHERE a.id = :afternoteId
+              AND ar.receiver.id = :receiverId
+              AND a.isDraft = false
             """)
     Optional<AfternoteReceiver> findByAfternoteIdAndReceiverIdWithAfternote(
             @Param("afternoteId") Long afternoteId,

--- a/src/test/java/com/afternote/domain/afternote/controller/AfternoteControllerTest.java
+++ b/src/test/java/com/afternote/domain/afternote/controller/AfternoteControllerTest.java
@@ -57,7 +57,7 @@ class AfternoteControllerTest {
     @Test
     @DisplayName("애프터노트 목록 조회 API 성공")
     void getAfternotes_Success() throws Exception {
-        given(afternoteService.getAfternotes(USER_ID, AfternoteCategoryType.SOCIAL, 0, 10)).willReturn(null);
+        given(afternoteService.getAfternotes(USER_ID, AfternoteCategoryType.SOCIAL, 0, 10, null)).willReturn(null);
 
         mockMvc.perform(get("/api/v1/afternotes")
                         .requestAttr(UserIdArgumentResolver.USER_ID_ATTRIBUTE, USER_ID)
@@ -66,7 +66,7 @@ class AfternoteControllerTest {
                         .param("size", "10"))
                 .andExpect(status().isOk());
 
-        verify(afternoteService).getAfternotes(USER_ID, AfternoteCategoryType.SOCIAL, 0, 10);
+        verify(afternoteService).getAfternotes(USER_ID, AfternoteCategoryType.SOCIAL, 0, 10, null);
     }
 
     @Test

--- a/src/test/java/com/afternote/domain/afternote/service/AfternoteServiceTest.java
+++ b/src/test/java/com/afternote/domain/afternote/service/AfternoteServiceTest.java
@@ -77,15 +77,18 @@ class AfternoteServiceTest {
                 .build();
         ReflectionTestUtils.setField(afternote, "id", 10L);
 
-        given(afternoteRepository.findByUserIdAndCategoryTypeOrderByCreatedAtDesc(eq(1L), eq(AfternoteCategoryType.SOCIAL), any(Pageable.class)))
+        given(afternoteRepository.findByUserIdAndCategoryTypeAndIsDraftOrderByCreatedAtDesc(
+                eq(1L), eq(AfternoteCategoryType.SOCIAL), eq(false), any(Pageable.class)))
                 .willReturn(new PageImpl<>(List.of(afternote)));
 
-        AfternotePageResponse response = afternoteService.getAfternotes(1L, AfternoteCategoryType.SOCIAL, 0, 10);
+        AfternotePageResponse response = afternoteService.getAfternotes(1L, AfternoteCategoryType.SOCIAL, 0, 10, null);
 
         assertThat(response.getContent()).hasSize(1);
         assertThat(response.getContent().get(0).getAfternoteId()).isEqualTo(10L);
-        verify(afternoteRepository).findByUserIdAndCategoryTypeOrderByCreatedAtDesc(eq(1L), eq(AfternoteCategoryType.SOCIAL), any(Pageable.class));
-        verify(afternoteRepository, never()).findByUserIdOrderByCreatedAtDesc(any(), any(Pageable.class));
+        assertThat(response.getContent().get(0).getIsDraft()).isFalse();
+        verify(afternoteRepository).findByUserIdAndCategoryTypeAndIsDraftOrderByCreatedAtDesc(
+                eq(1L), eq(AfternoteCategoryType.SOCIAL), eq(false), any(Pageable.class));
+        verify(afternoteRepository, never()).findByUserIdAndIsDraftOrderByCreatedAtDesc(any(), any(), any(Pageable.class));
     }
 
     @Test
@@ -115,10 +118,36 @@ class AfternoteServiceTest {
         ArgumentCaptor<Afternote> captor = ArgumentCaptor.forClass(Afternote.class);
         verify(afternoteRepository).save(captor.capture());
         assertThat(captor.getValue().getSortOrder()).isEqualTo(3);
+        assertThat(captor.getValue().getIsDraft()).isFalse();
         assertThat(captor.getValue().getLeaveMessage()).hasSize(1);
         assertThat(captor.getValue().getLeaveMessage().get(0).getBody()).isEqualTo("message");
         verify(validator).validateCreateRequest(request);
         verify(relationService).saveRelationsByCategory(any(Afternote.class), eq(request));
+    }
+
+    @Test
+    @DisplayName("애프터노트 임시저장 생성 성공")
+    void createAfternote_Draft_Success() {
+        AfternoteCreateRequest request = org.mockito.Mockito.mock(AfternoteCreateRequest.class);
+        given(request.getCategory()).willReturn(AfternoteCategoryType.SOCIAL);
+        given(request.getTitle()).willReturn("draft social");
+        given(request.isDraftValue()).willReturn(true);
+
+        User user = sampleUser(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(afternoteRepository.findMaxSortOrderByUserId(1L)).willReturn(Optional.empty());
+        given(afternoteRepository.save(any(Afternote.class))).willAnswer(invocation -> {
+            Afternote saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 102L);
+            return saved;
+        });
+
+        AfternoteCreateResponse response = afternoteService.createAfternote(1L, request);
+
+        assertThat(response.getAfternoteId()).isEqualTo(102L);
+        ArgumentCaptor<Afternote> captor = ArgumentCaptor.forClass(Afternote.class);
+        verify(afternoteRepository).save(captor.capture());
+        assertThat(captor.getValue().getIsDraft()).isTrue();
     }
 
     @Test
@@ -212,6 +241,7 @@ class AfternoteServiceTest {
         assertThat(afternote.getLeaveMessage().get(0).getBody()).isEqualTo("after-message");
         assertThat(afternote.getActions()).containsExactly("a2", "a3");
         verify(validator).validateUpdateRequest(request, AfternoteCategoryType.SOCIAL);
+        verify(validator).validatePublishRequirements(request, afternote);
         verify(relationService).updateRelationsByCategory(afternote, request, AfternoteCategoryType.SOCIAL);
     }
 

--- a/src/test/java/com/afternote/domain/afternote/service/validation/AfternoteCreateValidationStrategyTest.java
+++ b/src/test/java/com/afternote/domain/afternote/service/validation/AfternoteCreateValidationStrategyTest.java
@@ -29,7 +29,25 @@ class AfternoteCreateValidationStrategyTest {
                 null,
                 new AfternoteCreateRequest.CredentialsRequest("id", "pw"),
                 null,
+                null,
                 null
+        );
+
+        assertThatCode(() -> social.validateCreate(request)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("SOCIAL 임시저장 - credentials 없어도 성공")
+    void social_DraftWithoutCredentials_Ok() {
+        AfternoteCreateRequest request = new AfternoteCreateRequest(
+                AfternoteCategoryType.SOCIAL,
+                "인스타그램",
+                null,
+                null,
+                null,
+                null,
+                null,
+                true
         );
 
         assertThatCode(() -> social.validateCreate(request)).doesNotThrowAnyException();
@@ -50,7 +68,8 @@ class AfternoteCreateValidationStrategyTest {
                         null,
                         List.of(new AfternoteCreateRequest.SongRequest("곡", "가수", null)),
                         null
-                )
+                ),
+                null
         );
 
         assertThatThrownBy(() -> social.validateCreate(request))
@@ -75,6 +94,7 @@ class AfternoteCreateValidationStrategyTest {
                 null,
                 new AfternoteCreateRequest.CredentialsRequest("id", "pw"),
                 List.of(new AfternoteCreateRequest.ReceiverRequest(1L)),
+                null,
                 null
         );
 
@@ -96,7 +116,8 @@ class AfternoteCreateValidationStrategyTest {
                         null,
                         List.of(new AfternoteCreateRequest.SongRequest("곡", "가수", null)),
                         null
-                )
+                ),
+                null
         );
 
         assertThatThrownBy(() -> social.validateUpdate(request))
@@ -121,6 +142,7 @@ class AfternoteCreateValidationStrategyTest {
                 null,
                 null,
                 List.of(),
+                null,
                 null
         );
 
@@ -142,7 +164,25 @@ class AfternoteCreateValidationStrategyTest {
                         null,
                         List.of(new AfternoteCreateRequest.SongRequest("곡", "가수", null)),
                         null
-                )
+                ),
+                null
+        );
+
+        assertThatCode(() -> playlist.validateCreate(request)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("PLAYLIST 임시저장 - playlist 없어도 성공")
+    void playlist_DraftWithoutPlaylist_Ok() {
+        AfternoteCreateRequest request = new AfternoteCreateRequest(
+                AfternoteCategoryType.PLAYLIST,
+                "추억 노트",
+                null,
+                null,
+                null,
+                null,
+                null,
+                true
         );
 
         assertThatCode(() -> playlist.validateCreate(request)).doesNotThrowAnyException();


### PR DESCRIPTION
## Summary
- 애프터노트에 Diary와 동일한 `isDraft` / `draftOnly`를 추가합니다.
- draft 생성 시 SOCIAL credentials·PLAYLIST songs 필수 검증을 완화하고, 정식 등록(publish) 시 기존+요청 기준으로 재검증합니다.
- 기본 목록·수신자 전달 경로에서는 draft를 제외합니다.

Closes #130

## Test plan
- [ ] `POST /api/v1/afternotes` with `isDraft: true` (SOCIAL without credentials) → 201/200
- [ ] `GET /api/v1/afternotes` default → draft 미포함
- [ ] `GET /api/v1/afternotes?draftOnly=true` → draft만
- [ ] draft를 `isDraft: false`로 PATCH 시 credentials/playlist 없으면 4xx
- [ ] 수신자 애프터노트 목록에 draft 미노출


Made with [Cursor](https://cursor.com)