### PR TITLE
refactor: week[] isDiary → type enum + OpenAPI 표기

### DIFF
--- a/src/main/java/com/afternote/domain/mindrecord/weekly/dto/WeekRecordType.java
+++ b/src/main/java/com/afternote/domain/mindrecord/weekly/dto/WeekRecordType.java
@@ -1,0 +1,10 @@
+package com.afternote.domain.mindrecord.weekly.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "주간 캘린더 week[] 아이템 타입")
+public enum WeekRecordType {
+    DIARY,
+    DAILY_QUESTION,
+    DEEP_THOUGHT
+}

--- a/src/main/java/com/afternote/domain/mindrecord/weekly/dto/WeeklyMindRecordResponse.java
+++ b/src/main/java/com/afternote/domain/mindrecord/weekly/dto/WeeklyMindRecordResponse.java
@@ -67,21 +67,34 @@ public record WeeklyMindRecordResponse(
 
     @Builder
     public static record WeekRecordItem(
+            @Schema(
+                    description = "원본 기록 ID (맵/리스트 키). type에 따라 일기/데일리질문/깊은생각 PK",
+                    example = "27",
+                    requiredMode = Schema.RequiredMode.REQUIRED
+            )
             @Getter
             Long diaryId,
 
+            @Schema(description = "일(day of month)", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
             @Getter
             int day,
 
-            @Schema(description = "일기 여부. true면 일기, false면 데일리질문/깊은생각 등")
-            boolean isDiary,
+            @Schema(
+                    description = "기록 타입. DIARY=일기, DAILY_QUESTION=데일리질문, DEEP_THOUGHT=깊은생각",
+                    example = "DIARY",
+                    requiredMode = Schema.RequiredMode.REQUIRED
+            )
+            @Getter
+            WeekRecordType type,
 
             @Schema(
                     description = "주간 캘린더 이모지용 일기 todayMood (HAPPY/SOSO/SAD). "
-                            + "일기만 채우고, Gemini 감정분석 결과는 emotions[]에만 둔다.",
+                            + "type=DIARY일 때만 채우고, Gemini 감정분석 결과는 emotions[]에만 둔다. "
+                            + "DIARY가 아니면 null(점 표시).",
                     example = "HAPPY",
                     allowableValues = {"HAPPY", "SOSO", "SAD"},
-                    nullable = true
+                    nullable = true,
+                    requiredMode = Schema.RequiredMode.NOT_REQUIRED
             )
             @Getter
             String emotion

--- a/src/main/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordService.java
+++ b/src/main/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordService.java
@@ -12,6 +12,7 @@ import com.afternote.domain.mindrecord.emotion.model.EmotionSourceType;
 import com.afternote.domain.mindrecord.emotion.repository.EmotionRepository;
 import com.afternote.domain.mindrecord.weekly.dto.WeeklyMindRecordResponse;
 import com.afternote.domain.mindrecord.weekly.dto.WeeklyMindRecordResponse.EmotionAnalysisSummary;
+import com.afternote.domain.mindrecord.weekly.dto.WeekRecordType;
 import com.afternote.domain.mindrecord.weekly.dto.WeeklyMindRecordResponse.WeekRecordItem;
 import com.afternote.domain.mindrecord.weekly.dto.WeeklyMindRecordResponse.WeeklyDailyQuestionItem;
 import com.afternote.domain.mindrecord.weekly.dto.WeeklyMindRecordResponse.WeeklyEmotionItem;
@@ -324,7 +325,7 @@ public class WeeklyMindRecordService {
             sortables.add(new Sortable(at, WeekRecordItem.builder()
                     .diaryId(d.getId())
                     .day(at.toLocalDate().getDayOfMonth())
-                    .isDiary(true)
+                    .type(WeekRecordType.DIARY)
                     .emotion(todayMood)
                     .build()));
         }
@@ -334,7 +335,7 @@ public class WeeklyMindRecordService {
             sortables.add(new Sortable(at, WeekRecordItem.builder()
                     .diaryId(u.getId())
                     .day(u.getQuestionDate().getDayOfMonth())
-                    .isDiary(false)
+                    .type(WeekRecordType.DAILY_QUESTION)
                     .emotion(null)
                     .build()));
         }
@@ -344,7 +345,7 @@ public class WeeklyMindRecordService {
             sortables.add(new Sortable(at, WeekRecordItem.builder()
                     .diaryId(dt.getId())
                     .day(at.toLocalDate().getDayOfMonth())
-                    .isDiary(false)
+                    .type(WeekRecordType.DEEP_THOUGHT)
                     .emotion(null)
                     .build()));
         }

--- a/src/test/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordServiceWeekItemsTest.java
+++ b/src/test/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordServiceWeekItemsTest.java
@@ -10,6 +10,7 @@ import com.afternote.domain.diary.repository.DiaryRepository;
 import com.afternote.domain.mindrecord.emotion.model.Emotion;
 import com.afternote.domain.mindrecord.emotion.model.EmotionSourceType;
 import com.afternote.domain.mindrecord.emotion.repository.EmotionRepository;
+import com.afternote.domain.mindrecord.weekly.dto.WeekRecordType;
 import com.afternote.domain.mindrecord.weekly.dto.WeeklyMindRecordResponse.WeekRecordItem;
 import com.afternote.domain.mindrecord.weekly.repository.WeeklyReportRepository;
 import com.afternote.domain.user.model.AuthProvider;
@@ -117,14 +118,14 @@ class WeeklyMindRecordServiceWeekItemsTest {
         assertThat(response.week()).hasSize(2);
 
         WeekRecordItem diaryItem = response.week().stream()
-                .filter(WeekRecordItem::isDiary)
+                .filter(item -> item.type() == WeekRecordType.DIARY)
                 .findFirst()
                 .orElseThrow();
         assertThat(diaryItem.emotion()).isEqualTo("HAPPY");
         assertThat(diaryItem.emotion()).isNotEqualTo("기쁨");
 
         WeekRecordItem dqItem = response.week().stream()
-                .filter(item -> !item.isDiary())
+                .filter(item -> item.type() == WeekRecordType.DAILY_QUESTION)
                 .findFirst()
                 .orElseThrow();
         assertThat(dqItem.emotion()).isNull();


### PR DESCRIPTION
## Summary
- `week[].isDiary` boolean을 `type` enum(`DIARY` / `DAILY_QUESTION` / `DEEP_THOUGHT`)으로 교체합니다.
- `WeekRecordItem` OpenAPI에 `requiredMode` / `nullable`을 명시해 Swagger required·nullable 표기를 보강합니다.
- `diaryId`는 타입별 원본 PK(맵 키)로 유지합니다.

## Test plan
- [ ] `GET /api/v1/mind-record?date=yyyy-MM-dd` 응답 `week[]`에 `type` 존재, `isDiary` 없음
- [ ] 일기 아이템: `type=DIARY`, `emotion`이 todayMood
- [ ] DQ/깊은생각: `type=DAILY_QUESTION|DEEP_THOUGHT`, `emotion=null`
- [ ] Swagger `WeekRecordItem`에 required / emotion nullable 표시 확인


Made with [Cursor](https://cursor.com)