### PR TITLE
fix: week[] day당 1개 (일기 우선·최신 todayMood)

### DIFF
--- a/src/main/java/com/afternote/domain/mindrecord/weekly/dto/WeeklyMindRecordResponse.java
+++ b/src/main/java/com/afternote/domain/mindrecord/weekly/dto/WeeklyMindRecordResponse.java
@@ -27,7 +27,7 @@ public record WeeklyMindRecordResponse(
         @Getter
         String summaryText,
 
-        @Schema(description = "해당 주 기록 타임라인")
+        @Schema(description = "해당 주 캘린더(day당 1개). 일기 우선, 같은 날 일기 여러 개면 최신 todayMood")
         @Getter
         List<WeekRecordItem> week,
 

--- a/src/main/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordService.java
+++ b/src/main/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordService.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -308,51 +309,92 @@ public class WeeklyMindRecordService {
         }
     }
 
+    /**
+     * 주간 캘린더는 day(날짜)당 1개.
+     * - 일기 있으면 → DIARY 우선, 같은 날 일기 여러 개면 최신(createdAt) todayMood
+     * - 일기 없음 → 데일리질문/깊은생각 중 최신 1개 (emotion=null, 점 표시)
+     */
     private List<WeekRecordItem> buildWeekItems(
             List<Diary> diaries,
             List<UserDailyQuestion> dailyQuestions,
             List<DeepThought> deepThoughts
     ) {
-        record Sortable(LocalDateTime at, WeekRecordItem item) {
+        record Candidate(LocalDate date, LocalDateTime at, WeekRecordItem item) {
         }
 
-        List<Sortable> sortables = new ArrayList<>();
+        Map<LocalDate, List<Candidate>> diariesByDate = new HashMap<>();
+        Map<LocalDate, List<Candidate>> othersByDate = new HashMap<>();
 
         for (Diary d : diaries) {
             LocalDateTime at = d.getCreatedAt() != null ? d.getCreatedAt() : d.getUpdatedAt();
-            // 캘린더 이모지 = todayMood 만 (HAPPY/SOSO/SAD). 분석 카테고리는 emotions[] 전용.
+            if (at == null) {
+                continue;
+            }
+            LocalDate date = at.toLocalDate();
             String todayMood = d.getTodayMood() != null ? d.getTodayMood().name() : null;
-            sortables.add(new Sortable(at, WeekRecordItem.builder()
-                    .diaryId(d.getId())
-                    .day(at.toLocalDate().getDayOfMonth())
-                    .type(WeekRecordType.DIARY)
-                    .emotion(todayMood)
-                    .build()));
+            diariesByDate.computeIfAbsent(date, ignored -> new ArrayList<>()).add(new Candidate(
+                    date,
+                    at,
+                    WeekRecordItem.builder()
+                            .diaryId(d.getId())
+                            .day(date.getDayOfMonth())
+                            .type(WeekRecordType.DIARY)
+                            .emotion(todayMood)
+                            .build()
+            ));
         }
 
         for (UserDailyQuestion u : dailyQuestions) {
             LocalDateTime at = u.getCreatedAt() != null ? u.getCreatedAt() : u.getQuestionDate().atStartOfDay();
-            sortables.add(new Sortable(at, WeekRecordItem.builder()
-                    .diaryId(u.getId())
-                    .day(u.getQuestionDate().getDayOfMonth())
-                    .type(WeekRecordType.DAILY_QUESTION)
-                    .emotion(null)
-                    .build()));
+            LocalDate date = u.getQuestionDate();
+            othersByDate.computeIfAbsent(date, ignored -> new ArrayList<>()).add(new Candidate(
+                    date,
+                    at,
+                    WeekRecordItem.builder()
+                            .diaryId(u.getId())
+                            .day(date.getDayOfMonth())
+                            .type(WeekRecordType.DAILY_QUESTION)
+                            .emotion(null)
+                            .build()
+            ));
         }
 
         for (DeepThought dt : deepThoughts) {
             LocalDateTime at = dt.getCreatedAt() != null ? dt.getCreatedAt() : dt.getUpdatedAt();
-            sortables.add(new Sortable(at, WeekRecordItem.builder()
-                    .diaryId(dt.getId())
-                    .day(at.toLocalDate().getDayOfMonth())
-                    .type(WeekRecordType.DEEP_THOUGHT)
-                    .emotion(null)
-                    .build()));
+            if (at == null) {
+                continue;
+            }
+            LocalDate date = at.toLocalDate();
+            othersByDate.computeIfAbsent(date, ignored -> new ArrayList<>()).add(new Candidate(
+                    date,
+                    at,
+                    WeekRecordItem.builder()
+                            .diaryId(dt.getId())
+                            .day(date.getDayOfMonth())
+                            .type(WeekRecordType.DEEP_THOUGHT)
+                            .emotion(null)
+                            .build()
+            ));
         }
 
-        return sortables.stream()
-                .sorted(Comparator.comparing(Sortable::at))
-                .map(Sortable::item)
+        return Stream.concat(diariesByDate.keySet().stream(), othersByDate.keySet().stream())
+                .distinct()
+                .sorted()
+                .map(date -> {
+                    List<Candidate> dayDiaries = diariesByDate.get(date);
+                    if (dayDiaries != null && !dayDiaries.isEmpty()) {
+                        // 최신 일기 1개 → 그 일기의 todayMood(이모지)
+                        return dayDiaries.stream()
+                                .max(Comparator.comparing(Candidate::at))
+                                .map(Candidate::item)
+                                .orElseThrow();
+                    }
+                    List<Candidate> dayOthers = othersByDate.getOrDefault(date, List.of());
+                    return dayOthers.stream()
+                            .max(Comparator.comparing(Candidate::at))
+                            .map(Candidate::item)
+                            .orElseThrow();
+                })
                 .toList();
     }
 }

--- a/src/test/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordServiceWeekItemsTest.java
+++ b/src/test/java/com/afternote/domain/mindrecord/weekly/service/WeeklyMindRecordServiceWeekItemsTest.java
@@ -64,30 +64,12 @@ class WeeklyMindRecordServiceWeekItemsTest {
     @Test
     @DisplayName("week[].emotion 은 todayMood만 쓰고 Gemini 분석 카테고리는 넣지 않는다")
     void weekEmotion_usesTodayMoodOnly_notAnalyzedCategory() throws Exception {
-        ReflectionTestUtils.setField(weeklyMindRecordService, "objectMapper", new ObjectMapper());
-
+        stubCommon();
         User user = sampleUser(1L);
         LocalDate monday = LocalDate.of(2026, 8, 3);
 
-        Diary diary = Diary.create(user, "제목", "본문", false, TodayMood.HAPPY);
-        ReflectionTestUtils.setField(diary, "id", 7L);
-        ReflectionTestUtils.setField(diary, "createdAt", monday.plusDays(1).atTime(10, 0));
-        ReflectionTestUtils.setField(diary, "updatedAt", monday.plusDays(1).atTime(10, 0));
-
-        DailyQuestion question = new DailyQuestion();
-        ReflectionTestUtils.setField(question, "id", 1L);
-        ReflectionTestUtils.setField(question, "content", "질문");
-
-        UserDailyQuestion dq = UserDailyQuestion.builder()
-                .user(user)
-                .dailyQuestion(question)
-                .questionDate(monday.plusDays(1))
-                .isAnswered(true)
-                .content("답변")
-                .isDraft(false)
-                .build();
-        ReflectionTestUtils.setField(dq, "id", 22L);
-        ReflectionTestUtils.setField(dq, "createdAt", monday.plusDays(1).atTime(11, 0));
+        Diary diary = diary(user, 7L, monday.plusDays(1).atTime(10, 0), TodayMood.HAPPY);
+        UserDailyQuestion dq = dailyQuestion(user, 22L, monday.plusDays(2), monday.plusDays(2).atTime(11, 0));
 
         Emotion analyzed = Emotion.createSucceeded(
                 user, EmotionSourceType.DIARY, 7L, "기쁨", LocalDateTime.now());
@@ -133,6 +115,74 @@ class WeeklyMindRecordServiceWeekItemsTest {
         assertThat(response.emotions())
                 .extracting(e -> e.keyword())
                 .contains("기쁨");
+    }
+
+    @Test
+    @DisplayName("같은 날 일기+DQ면 day당 1개(일기 우선), 일기 여러 개면 최신 todayMood")
+    void week_onePerDay_diaryPreferred_latestMood() {
+        stubCommon();
+        User user = sampleUser(1L);
+        LocalDate monday = LocalDate.of(2026, 8, 3);
+        LocalDate day = monday.plusDays(1);
+
+        Diary older = diary(user, 1L, day.atTime(9, 0), TodayMood.SAD);
+        Diary newer = diary(user, 2L, day.atTime(18, 0), TodayMood.HAPPY);
+        UserDailyQuestion dq = dailyQuestion(user, 30L, day, day.atTime(12, 0));
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(diaryRepository
+                .findByUserIdAndIsDraftFalseAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtAsc(
+                        any(), any(), any()))
+                .willReturn(List.of(older, newer));
+        given(userDailyQuestionRepository
+                .findByUserIdAndQuestionDateBetweenOrderByQuestionDateAscCreatedAtAsc(any(), any(), any()))
+                .willReturn(List.of(dq));
+        given(deepThoughtRepository
+                .findByUserIdAndIsDraftFalseAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtAsc(
+                        any(), any(), any()))
+                .willReturn(List.of());
+        given(emotionRepository.findByUserIdAndSourceTypeAndSourceIdIn(any(), any(), anyList()))
+                .willReturn(List.of());
+        given(weeklyReportRepository.findByUserIdAndStartDate(any(), any())).willReturn(Optional.empty());
+
+        var response = weeklyMindRecordService.getWeeklyMindRecord(1L, monday);
+
+        assertThat(response.week()).hasSize(1);
+        WeekRecordItem item = response.week().get(0);
+        assertThat(item.day()).isEqualTo(day.getDayOfMonth());
+        assertThat(item.type()).isEqualTo(WeekRecordType.DIARY);
+        assertThat(item.diaryId()).isEqualTo(2L);
+        assertThat(item.emotion()).isEqualTo("HAPPY");
+    }
+
+    private void stubCommon() {
+        ReflectionTestUtils.setField(weeklyMindRecordService, "objectMapper", new ObjectMapper());
+    }
+
+    private static Diary diary(User user, Long id, LocalDateTime at, TodayMood mood) {
+        Diary diary = Diary.create(user, "제목", "본문", false, mood);
+        ReflectionTestUtils.setField(diary, "id", id);
+        ReflectionTestUtils.setField(diary, "createdAt", at);
+        ReflectionTestUtils.setField(diary, "updatedAt", at);
+        return diary;
+    }
+
+    private static UserDailyQuestion dailyQuestion(User user, Long id, LocalDate questionDate, LocalDateTime at) {
+        DailyQuestion question = new DailyQuestion();
+        ReflectionTestUtils.setField(question, "id", 1L);
+        ReflectionTestUtils.setField(question, "content", "질문");
+
+        UserDailyQuestion dq = UserDailyQuestion.builder()
+                .user(user)
+                .dailyQuestion(question)
+                .questionDate(questionDate)
+                .isAnswered(true)
+                .content("답변")
+                .isDraft(false)
+                .build();
+        ReflectionTestUtils.setField(dq, "id", id);
+        ReflectionTestUtils.setField(dq, "createdAt", at);
+        return dq;
     }
 
     private static User sampleUser(Long id) {


### PR DESCRIPTION
## Summary
- `week[]`를 **날짜(day)당 1개**로 합칩니다.
- 같은 날 일기가 있으면 `type=DIARY` 우선 (DQ/깊은생각 제외).
- 같은 날 일기가 여러 개면 **createdAt 최신** 일기의 `todayMood`를 `emotion`으로 사용합니다.
- 일기 없으면 DQ/깊은생각 중 최신 1개 (`emotion=null`, 점 표시).

## Test plan
- [ ] 같은 날 일기 2개(SAD 후 HAPPY) → week 1개, emotion=HAPPY, 최신 diaryId
- [ ] 같은 날 일기+DQ → week 1개, type=DIARY
- [ ] 일기 없이 DQ만 → week 1개, type=DAILY_QUESTION, emotion=null


Made with [Cursor](https://cursor.com)