### PR TITLE
fix: 수신자 등록 응답 지연(#124) + deploy 브랜치 main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to EC2 with Docker
 
 on:
   push:
-    branches: ["release"]
+    branches: ["main"]
 
 permissions:
   contents: read

--- a/deploy/nginx/README.md
+++ b/deploy/nginx/README.md
@@ -1,7 +1,7 @@
 # nginx (EC2 배포 정본)
 
 이 디렉터리의 `nginx.conf`가 운영 EC2 `~/deploy/nginx/nginx.conf`의 **정본**입니다.  
-`release` 브랜치 배포 시 GitHub Actions가 서버로 동기화한 뒤 `nginx -t` + reload 합니다.
+`main` 브랜치 배포 시 GitHub Actions가 서버로 동기화한 뒤 `nginx -t` + reload 합니다.
 
 ## 포함 내용
 

--- a/src/main/java/com/afternote/domain/receiver/event/ReceiverAuthCodeEmailEventListener.java
+++ b/src/main/java/com/afternote/domain/receiver/event/ReceiverAuthCodeEmailEventListener.java
@@ -1,0 +1,18 @@
+package com.afternote.domain.receiver.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ReceiverAuthCodeEmailEventListener {
+
+    private final ReceiverAuthCodeEmailRunner runner;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onRequested(ReceiverAuthCodeEmailRequestedEvent event) {
+        runner.send(event);
+    }
+}

--- a/src/main/java/com/afternote/domain/receiver/event/ReceiverAuthCodeEmailRequestedEvent.java
+++ b/src/main/java/com/afternote/domain/receiver/event/ReceiverAuthCodeEmailRequestedEvent.java
@@ -1,0 +1,9 @@
+package com.afternote.domain.receiver.event;
+
+public record ReceiverAuthCodeEmailRequestedEvent(
+        Long receiverId,
+        String email,
+        String authCode,
+        String senderName,
+        String receiverName
+) {}

--- a/src/main/java/com/afternote/domain/receiver/event/ReceiverAuthCodeEmailRunner.java
+++ b/src/main/java/com/afternote/domain/receiver/event/ReceiverAuthCodeEmailRunner.java
@@ -1,0 +1,33 @@
+package com.afternote.domain.receiver.event;
+
+import com.afternote.domain.receiver.service.AuthCodeMessageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReceiverAuthCodeEmailRunner {
+
+    private final AuthCodeMessageService authCodeMessageService;
+
+    @Async
+    public void send(ReceiverAuthCodeEmailRequestedEvent event) {
+        try {
+            authCodeMessageService.sendAuthCode(
+                    event.email(),
+                    event.authCode(),
+                    event.senderName(),
+                    event.receiverName()
+            );
+        } catch (Exception e) {
+            log.warn(
+                    "Failed to send auth code via email for receiver {}: {}",
+                    event.receiverId(),
+                    e.getMessage()
+            );
+        }
+    }
+}

--- a/src/main/java/com/afternote/domain/user/service/UserService.java
+++ b/src/main/java/com/afternote/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.afternote.domain.auth.service.social.SocialLoginFactory;
 import com.afternote.domain.image.service.S3Service;
 import com.afternote.domain.receiver.model.Receiver;
 import com.afternote.domain.receiver.model.UserReceiver;
+import com.afternote.domain.receiver.event.ReceiverAuthCodeEmailRequestedEvent;
 import com.afternote.domain.receiver.service.DeliveryVerificationService;
 import com.afternote.domain.receiver.repository.ReceiverRepository;
 import com.afternote.domain.receiver.repository.UserReceiverRepository;
@@ -14,12 +15,11 @@ import com.afternote.domain.user.model.User;
 import com.afternote.domain.user.model.UserProvider;
 import com.afternote.domain.user.repository.UserProviderRepository;
 import com.afternote.domain.user.repository.UserRepository;
-import com.afternote.domain.receiver.service.AuthCodeMessageService;
 import com.afternote.global.exception.CustomException;
 import com.afternote.global.exception.ErrorCode;
 import com.afternote.global.util.PhoneNumbers;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -35,7 +34,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserReceiverRepository userReceiverRepository;
     private final ReceiverRepository receiverRepository;
-    private final AuthCodeMessageService authCodeMessageService;
+    private final ApplicationEventPublisher eventPublisher;
     private final S3Service s3Service;
     private final DeliveryVerificationService deliveryVerificationService;
     private final com.afternote.domain.auth.service.TokenService tokenService;
@@ -222,18 +221,14 @@ public class UserService {
 
         userReceiverRepository.save(userReceiver);
 
-        if (receiver.getEmail() != null && !receiver.getEmail().isBlank()) {
-            try {
-                authCodeMessageService.sendAuthCode(
-                        receiver.getEmail(),
-                        receiver.getAuthCode(),
-                        user.getName(),
-                        receiver.getName()
-                );
-            } catch (Exception e) {
-                log.warn("Failed to send auth code via email for receiver {}: {}", receiver.getId(), e.getMessage());
-            }
-        }
+        // SMTP는 커밋 후 비동기로 보내 요청 지연을 줄인다.
+        eventPublisher.publishEvent(new ReceiverAuthCodeEmailRequestedEvent(
+                receiver.getId(),
+                receiver.getEmail(),
+                receiver.getAuthCode(),
+                user.getName(),
+                receiver.getName()
+        ));
 
         return UserCreateReceiverResponse.from(receiver.getId(), receiver.getAuthCode());
     }

--- a/src/main/java/com/afternote/global/config/AsyncConfig.java
+++ b/src/main/java/com/afternote/global/config/AsyncConfig.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import java.util.concurrent.Executor;
 
 /**
- * 비동기 작업 설정 (감정 분석용)
+ * 비동기 작업 설정 (감정 분석, 인증메일 등)
  */
 @Configuration
 @EnableAsync
@@ -24,7 +24,7 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setCorePoolSize(2);  // 기본 스레드 수
         executor.setMaxPoolSize(5);   // 최대 스레드 수
         executor.setQueueCapacity(100);  // 큐 크기
-        executor.setThreadNamePrefix("emotion-analysis-");
+        executor.setThreadNamePrefix("async-");
         executor.initialize();
         return executor;
     }

--- a/src/test/java/com/afternote/domain/user/service/UserServiceCreateReceiverTest.java
+++ b/src/test/java/com/afternote/domain/user/service/UserServiceCreateReceiverTest.java
@@ -6,7 +6,7 @@ import com.afternote.domain.image.service.S3Service;
 import com.afternote.domain.receiver.model.Receiver;
 import com.afternote.domain.receiver.repository.ReceiverRepository;
 import com.afternote.domain.receiver.repository.UserReceiverRepository;
-import com.afternote.domain.receiver.service.AuthCodeMessageService;
+import com.afternote.domain.receiver.event.ReceiverAuthCodeEmailRequestedEvent;
 import com.afternote.domain.receiver.service.DeliveryVerificationService;
 import com.afternote.domain.user.dto.UserCreateReceiverRequest;
 import com.afternote.domain.user.model.AuthProvider;
@@ -19,9 +19,11 @@ import com.afternote.global.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
@@ -47,7 +49,7 @@ class UserServiceCreateReceiverTest {
     @Mock
     private ReceiverRepository receiverRepository;
     @Mock
-    private AuthCodeMessageService authCodeMessageService;
+    private ApplicationEventPublisher eventPublisher;
     @Mock
     private S3Service s3Service;
     @Mock
@@ -144,6 +146,14 @@ class UserServiceCreateReceiverTest {
 
         assertThat(response.receiverId()).isEqualTo(100L);
         verify(receiverRepository).save(any(Receiver.class));
+
+        ArgumentCaptor<ReceiverAuthCodeEmailRequestedEvent> eventCaptor =
+                ArgumentCaptor.forClass(ReceiverAuthCodeEmailRequestedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().receiverId()).isEqualTo(100L);
+        assertThat(eventCaptor.getValue().email()).isEqualTo("jieun@naver.com");
+        assertThat(eventCaptor.getValue().senderName()).isEqualTo("tester");
+        assertThat(eventCaptor.getValue().receiverName()).isEqualTo("김지은");
     }
 
     private static User sampleUser(Long id) {


### PR DESCRIPTION
## Summary
- `POST /api/v1/users/receivers`에서 인증메일 SMTP를 트랜잭션 커밋 후 `@Async`로 분리해 등록 API 응답 지연을 제거합니다. (#124)
- GitHub Actions deploy 트리거를 `release` → `main`으로 변경합니다.

## Test plan
- [ ] `UserServiceCreateReceiverTest` 통과
- [ ] 배포 후 `POST /api/v1/users/receivers` nginx `rt`가 수백 ms 이하로 내려가는지 확인
- [ ] 등록 직후 수신자 이메일로 인증코드가 도착하는지 확인 (비동기)
- [ ] `main` push 시 Deploy workflow가 실행되는지 확인


Made with [Cursor](https://cursor.com)